### PR TITLE
Use databases/pg to insert and delete rows instead of RDS service

### DIFF
--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -2349,6 +2349,14 @@
         "pg-cursor": "^2.4.2"
       }
     },
+    "node_modules/@databases/pg-bulk": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@databases/pg-bulk/-/pg-bulk-1.2.0.tgz",
+      "integrity": "sha512-GdzwFIllgOtuKbro4r6QBe0+4LipaUwb8+N7+z9QP+wg3XozGLnojnMFQlBrrc70jycw4aCM1O30w4vYtVlR/Q==",
+      "peerDependencies": {
+        "@databases/pg": "*"
+      }
+    },
     "node_modules/@databases/pg-config": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@databases/pg-config/-/pg-config-3.1.0.tgz",
@@ -2372,6 +2380,17 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@databases/pg-errors/-/pg-errors-1.0.0.tgz",
       "integrity": "sha512-Yz3exbptZwOn4ZD/MSwY6z++XVyOFsMh5DERvSw3awRwJFnfdaqdeiIxxX0MVjM6KPihF0xxp8lPO7vTc5ydpw=="
+    },
+    "node_modules/@databases/pg-typed": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@databases/pg-typed/-/pg-typed-4.3.0.tgz",
+      "integrity": "sha512-8Wds8k7zx1Eq3D9FUSjG/9lWYDFszwWJLUVYG73PKPRxof0r8ql3NuiY8BJWy1Z1exXsVbyD1cO2hKOM29Td6Q==",
+      "dependencies": {
+        "@databases/pg-bulk": "^1.2.0"
+      },
+      "peerDependencies": {
+        "@databases/pg": "*"
+      }
     },
     "node_modules/@databases/push-to-async-iterable": {
       "version": "3.0.0",
@@ -10515,6 +10534,12 @@
         "pg-cursor": "^2.4.2"
       }
     },
+    "@databases/pg-bulk": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@databases/pg-bulk/-/pg-bulk-1.2.0.tgz",
+      "integrity": "sha512-GdzwFIllgOtuKbro4r6QBe0+4LipaUwb8+N7+z9QP+wg3XozGLnojnMFQlBrrc70jycw4aCM1O30w4vYtVlR/Q==",
+      "requires": {}
+    },
     "@databases/pg-config": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@databases/pg-config/-/pg-config-3.1.0.tgz",
@@ -10538,6 +10563,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@databases/pg-errors/-/pg-errors-1.0.0.tgz",
       "integrity": "sha512-Yz3exbptZwOn4ZD/MSwY6z++XVyOFsMh5DERvSw3awRwJFnfdaqdeiIxxX0MVjM6KPihF0xxp8lPO7vTc5ydpw=="
+    },
+    "@databases/pg-typed": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@databases/pg-typed/-/pg-typed-4.3.0.tgz",
+      "integrity": "sha512-8Wds8k7zx1Eq3D9FUSjG/9lWYDFszwWJLUVYG73PKPRxof0r8ql3NuiY8BJWy1Z1exXsVbyD1cO2hKOM29Td6Q==",
+      "requires": {
+        "@databases/pg-bulk": "^1.2.0"
+      }
     },
     "@databases/push-to-async-iterable": {
       "version": "3.0.0",

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -2349,14 +2349,6 @@
         "pg-cursor": "^2.4.2"
       }
     },
-    "node_modules/@databases/pg-bulk": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@databases/pg-bulk/-/pg-bulk-1.2.0.tgz",
-      "integrity": "sha512-GdzwFIllgOtuKbro4r6QBe0+4LipaUwb8+N7+z9QP+wg3XozGLnojnMFQlBrrc70jycw4aCM1O30w4vYtVlR/Q==",
-      "peerDependencies": {
-        "@databases/pg": "*"
-      }
-    },
     "node_modules/@databases/pg-config": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@databases/pg-config/-/pg-config-3.1.0.tgz",
@@ -2380,17 +2372,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@databases/pg-errors/-/pg-errors-1.0.0.tgz",
       "integrity": "sha512-Yz3exbptZwOn4ZD/MSwY6z++XVyOFsMh5DERvSw3awRwJFnfdaqdeiIxxX0MVjM6KPihF0xxp8lPO7vTc5ydpw=="
-    },
-    "node_modules/@databases/pg-typed": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@databases/pg-typed/-/pg-typed-4.3.0.tgz",
-      "integrity": "sha512-8Wds8k7zx1Eq3D9FUSjG/9lWYDFszwWJLUVYG73PKPRxof0r8ql3NuiY8BJWy1Z1exXsVbyD1cO2hKOM29Td6Q==",
-      "dependencies": {
-        "@databases/pg-bulk": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@databases/pg": "*"
-      }
     },
     "node_modules/@databases/push-to-async-iterable": {
       "version": "3.0.0",
@@ -10534,12 +10515,6 @@
         "pg-cursor": "^2.4.2"
       }
     },
-    "@databases/pg-bulk": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@databases/pg-bulk/-/pg-bulk-1.2.0.tgz",
-      "integrity": "sha512-GdzwFIllgOtuKbro4r6QBe0+4LipaUwb8+N7+z9QP+wg3XozGLnojnMFQlBrrc70jycw4aCM1O30w4vYtVlR/Q==",
-      "requires": {}
-    },
     "@databases/pg-config": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@databases/pg-config/-/pg-config-3.1.0.tgz",
@@ -10563,14 +10538,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@databases/pg-errors/-/pg-errors-1.0.0.tgz",
       "integrity": "sha512-Yz3exbptZwOn4ZD/MSwY6z++XVyOFsMh5DERvSw3awRwJFnfdaqdeiIxxX0MVjM6KPihF0xxp8lPO7vTc5ydpw=="
-    },
-    "@databases/pg-typed": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@databases/pg-typed/-/pg-typed-4.3.0.tgz",
-      "integrity": "sha512-8Wds8k7zx1Eq3D9FUSjG/9lWYDFszwWJLUVYG73PKPRxof0r8ql3NuiY8BJWy1Z1exXsVbyD1cO2hKOM29Td6Q==",
-      "requires": {
-        "@databases/pg-bulk": "^1.2.0"
-      }
     },
     "@databases/push-to-async-iterable": {
       "version": "3.0.0",

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -11,6 +11,7 @@
         "@aws-cdk/aws-lambda": "^1.156.1",
         "@aws-sdk/client-secrets-manager": "^3.92.0",
         "@databases/pg": "^5.4.1",
+        "@databases/pg-bulk": "^1.2.0",
         "aws-cdk-lib": "2.21.1",
         "constructs": "^10.0.0",
         "csv-parser": "^3.0.0",
@@ -2347,6 +2348,14 @@
         "cuid": "^2.1.8",
         "pg": "^8.4.2",
         "pg-cursor": "^2.4.2"
+      }
+    },
+    "node_modules/@databases/pg-bulk": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@databases/pg-bulk/-/pg-bulk-1.2.0.tgz",
+      "integrity": "sha512-GdzwFIllgOtuKbro4r6QBe0+4LipaUwb8+N7+z9QP+wg3XozGLnojnMFQlBrrc70jycw4aCM1O30w4vYtVlR/Q==",
+      "peerDependencies": {
+        "@databases/pg": "*"
       }
     },
     "node_modules/@databases/pg-config": {
@@ -10514,6 +10523,12 @@
         "pg": "^8.4.2",
         "pg-cursor": "^2.4.2"
       }
+    },
+    "@databases/pg-bulk": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@databases/pg-bulk/-/pg-bulk-1.2.0.tgz",
+      "integrity": "sha512-GdzwFIllgOtuKbro4r6QBe0+4LipaUwb8+N7+z9QP+wg3XozGLnojnMFQlBrrc70jycw4aCM1O30w4vYtVlR/Q==",
+      "requires": {}
     },
     "@databases/pg-config": {
       "version": "3.1.0",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -22,9 +22,9 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
+    "@aws-cdk/aws-lambda": "^1.156.1",
     "@aws-sdk/client-secrets-manager": "^3.92.0",
     "@databases/pg": "^5.4.1",
-    "@aws-cdk/aws-lambda": "^1.156.1",
     "aws-cdk-lib": "2.21.1",
     "constructs": "^10.0.0",
     "csv-parser": "^3.0.0",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -25,6 +25,7 @@
     "@aws-cdk/aws-lambda": "^1.156.1",
     "@aws-sdk/client-secrets-manager": "^3.92.0",
     "@databases/pg": "^5.4.1",
+    "@databases/pg-bulk": "^1.2.0",
     "aws-cdk-lib": "2.21.1",
     "constructs": "^10.0.0",
     "csv-parser": "^3.0.0",

--- a/cdk/src/open-data-platform/data-plane/data-plane-stack.ts
+++ b/cdk/src/open-data-platform/data-plane/data-plane-stack.ts
@@ -7,8 +7,6 @@ import { Construct } from 'constructs';
 import { CommonProps } from '../../util';
 import { Schema } from './schema';
 import {DataImportStack} from '../lambda/data-import-stack';
-import {DatabaseUserCredentials} from './db-user-credentials';
-import {ConnectionString} from './connection-string';
 
 interface DataPlaneProps extends CommonProps {
   vpc: ec2.IVpc;
@@ -16,8 +14,6 @@ interface DataPlaneProps extends CommonProps {
 
 export class DataPlaneStack extends Stack {
   readonly cluster: rds.ServerlessCluster;
-  readonly tileserverCredentials: DatabaseUserCredentials;
-  readonly tileserverConnectionString: ConnectionString;
 
   constructor(scope: Construct, id: string, props: DataPlaneProps) {
     super(scope, id, props);
@@ -53,27 +49,14 @@ export class DataPlaneStack extends Stack {
     // default DB name.
     const dbName = 'postgres';
 
-    // Credentials for the tile server to access the cluster.
-    this.tileserverCredentials = new DatabaseUserCredentials(this, 'MainClusterMartinTileserverCredentials', {
-      cluster: this.cluster,
-      username: 'tileserver'
-    })
-
-    new ConnectionString(this, 'MartinTileserverConnectionString', {
-      sourceSecret: this.tileserverCredentials.secret,
-      databaseName: dbName
-    })
-
     // Initialize the DB with linked SQL file.
-    const rootSchema = new Schema(this, 'RootSchema', {
+    new Schema(this, 'RootSchema', {
       cluster: this.cluster,
       vpc,
       db: dbName,
       schemaFileName: 'schema.sql',
       credentialsSecret: this.cluster.secret!,
-      userCredentials: [this.tileserverCredentials.secret]
     });
-    rootSchema.node.addDependency(this.tileserverCredentials.secret);
 
     new DataImportStack(this, 'DataImportStack', {
       cluster: this.cluster,

--- a/cdk/src/open-data-platform/lambda/data-import-stack.ts
+++ b/cdk/src/open-data-platform/lambda/data-import-stack.ts
@@ -20,7 +20,7 @@ export class DataImportStack extends Construct {
 
     const writeDemographicDataFunction =
       new lambda.NodejsFunction(this, 'write-demographic-data-handler', {
-        entry: `${path.resolve(__dirname)}/write-demographic-data-handler.ts`,
+        entry: `${path.resolve(__dirname)}/write-demographic-data.handler.ts`,
         handler: 'handler',
         vpc: vpc,
         vpcSubnets: {subnetType: ec2.SubnetType.PRIVATE_WITH_NAT},

--- a/cdk/src/open-data-platform/lambda/data-import-stack.ts
+++ b/cdk/src/open-data-platform/lambda/data-import-stack.ts
@@ -31,7 +31,7 @@ export class DataImportStack extends Construct {
         timeout: Duration.minutes(5),
         bundling: {
           externalModules: ['aws-sdk'],
-          nodeModules: ['csv-parser'],
+          nodeModules: ['csv-parser', '@databases/pg', '@databases/pg-bulk'],
         },
       });
 

--- a/cdk/src/open-data-platform/lambda/write-demographic-data-handler.ts
+++ b/cdk/src/open-data-platform/lambda/write-demographic-data-handler.ts
@@ -123,7 +123,6 @@ function parseS3IntoDemographicsTableRow(
             (dataRow) => {
               // Pause to allow for processing.
               fileStream.pause();
-              // Only process 10 rows for now.
               if (count < numberRowsToWrite) {
                 const row =
                     new DemographicsTableRowBuilder()

--- a/cdk/src/open-data-platform/lambda/write-demographic-data-handler.ts
+++ b/cdk/src/open-data-platform/lambda/write-demographic-data-handler.ts
@@ -14,7 +14,9 @@ const RACE_TOTAL = 'RaceTotal';
 const WHITE_POPULATION = 'Estimate!!Total:!!White alone';
 const BLACK_POPULATION = 'Estimate!!Total:!!Black or African American alone';
 
-// Establishes connection with DB with the given ARN.
+/**
+ * Establishes connection with DB with the given ARN.
+ */
 function connectToDb(secretArn: string): Promise<ConnectionPool> {
   return new Promise(async function(resolve, reject) {
     try {
@@ -25,8 +27,8 @@ function connectToDb(secretArn: string): Promise<ConnectionPool> {
           JSON.parse(secretInfo.SecretString!);
 
       const config: ConnectionPoolConfig = {
-        host: host,
-        port: port,
+        host,
+        port,
         user: username,
         password: password,
       };
@@ -77,7 +79,9 @@ function connectToDb(secretArn: string): Promise<ConnectionPool> {
   });
 }
 
-// Inserts all rows into the demographics table.
+/**
+ * Inserts all rows into the demographics table.
+ */
 async function insertRows(
     db: Queryable, rows: DemographicsTableRow[]): Promise<any[]> {
   const rowOptions:
@@ -93,24 +97,28 @@ async function insertRows(
         },
       };
 
-  return Promise.all([bulkInsert({
+  return bulkInsert({
     ...rowOptions,
     columnsToInsert: [
       `census_geo_id`, `total_population`, `black_percentage`,
       `white_percentage`
     ],
     records: rows,
-  })]);
+  });
 }
 
-// Inserts all rows into the demographics table.
-async function deleteRows(db: Queryable): Promise<any[]> {
+/**
+ * Inserts all rows into the demographics table.
+ */
+async function deleteRows(db: Queryable): Promise<any[]>  {
   return db.query(sql`DELETE
           FROM demographics
           WHERE census_geo_id IS NOT NULL`);
 }
 
-// Reads the S3 CSV file and returns [DemographicsTableRow]s.
+/**
+ * Reads the S3 CSV file and returns [DemographicsTableRow]s.
+ */
 function parseS3IntoDemographicsTableRow(
     s3Params: Object,
     numberRowsToWrite = 10): Promise<Array<DemographicsTableRow>> {
@@ -147,7 +155,7 @@ function parseS3IntoDemographicsTableRow(
   });
 }
 
-/*
+/**
  * Parses S3 'alabama_acs_data.csv' file and writes rows
  * to demographics table in the MainCluster postgres db.
  */
@@ -177,7 +185,7 @@ exports.handler = async(event: APIGatewayEvent): Promise<Object> => {
       resolve({statusCode: 200, body: JSON.stringify(data)});
 
     } catch (error) {
-      console.log('Error:' + JSON.stringify(error));
+      console.log('Error:' + error);
       reject({statusCode: 500, body: JSON.stringify(error.message)});
 
     } finally {
@@ -187,7 +195,9 @@ exports.handler = async(event: APIGatewayEvent): Promise<Object> => {
   });
 };
 
-// Single row for demographics table.
+/**
+ * Single row for demographics table.
+ */
 class DemographicsTableRow {
   // Field formatting conforms to rows in the db. Requires less tranformations.
   census_geo_id: string;
@@ -221,7 +231,9 @@ class DemographicsTableRow {
   }
 }
 
-// Builder utility for rows of the Demographics table.
+/**
+ * Builder utility for rows of the Demographics table.
+ */
 class DemographicsTableRowBuilder {
   private readonly _row: DemographicsTableRow;
 

--- a/cdk/src/open-data-platform/lambda/write-demographic-data.handler.ts
+++ b/cdk/src/open-data-platform/lambda/write-demographic-data.handler.ts
@@ -17,66 +17,57 @@ const BLACK_POPULATION = 'Estimate!!Total:!!Black or African American alone';
 /**
  * Establishes connection with DB with the given ARN.
  */
-function connectToDb(secretArn: string): Promise<ConnectionPool> {
-  return new Promise(async function(resolve, reject) {
-    try {
-      console.log('Fetching db credentials...');
-      const secretInfo =
-          await secretsmanager.getSecretValue({SecretId: secretArn});
-      const {host, port, username, password} =
-          JSON.parse(secretInfo.SecretString!);
+async function connectToDb(secretArn: string): Promise<ConnectionPool> {
+  console.log('Fetching db credentials...');
+  const secretInfo = await secretsmanager.getSecretValue({SecretId: secretArn});
+  const {host, port, username, password} = JSON.parse(secretInfo.SecretString!);
 
-      const config: ConnectionPoolConfig = {
-        host,
-        port,
-        user: username,
-        password: password,
-      };
+  const config: ConnectionPoolConfig = {
+    host,
+    port,
+    user: username,
+    password: password,
+  };
 
-      console.log('Connecting to database...');
-      let connectionsCount = 0;
+  console.log('Connecting to database...');
+  let connectionsCount = 0;
 
-      let pool = createConnectionPool({
-        ...config,
-        onError: (err: Error) => {
-            console.log(`${new Date().toISOString()} ERROR - ${err.message}`)},
-        onConnectionOpened: () => {
-          console.log(
-              `Opened connection. Active connections = ${++connectionsCount}`,
-          );
-        },
-        onConnectionClosed: () => {
-          console.log(
-              `Closed connection. Active connections = ${--connectionsCount}`,
-          );
-        },
-        onQueryStart: (_query, {text, values}) => {
-          console.log(
-              `${new Date().toISOString()} START QUERY ${text} - ${
-                  JSON.stringify(
-                      values,
-                      )}`,
-          );
-        },
-        onQueryResults: (_query, {text}, results) => {
-          console.log(
-              `${new Date().toISOString()} END QUERY   ${text} - ${
-                  results.length} results`,
-          );
-        },
-        onQueryError: (_query, {text}, err) => {
-          console.log(
-              `${new Date().toISOString()} ERROR QUERY ${text} - ${
-                  err.message}`,
-          );
-        },
-      });
-      console.log('Finished connecting to database...');
-      resolve(pool);
-    } catch (error) {
-      reject(error);
-    }
+  let pool = createConnectionPool({
+    ...config,
+    onError: (err: Error) => {
+        console.log(`${new Date().toISOString()} ERROR - ${err.message}`)},
+    onConnectionOpened: () => {
+      console.log(
+          `Opened connection. Active connections = ${++connectionsCount}`,
+      );
+    },
+    onConnectionClosed: () => {
+      console.log(
+          `Closed connection. Active connections = ${--connectionsCount}`,
+      );
+    },
+    onQueryStart: (_query, {text, values}) => {
+      console.log(
+          `${new Date().toISOString()} START QUERY ${text} - ${
+              JSON.stringify(
+                  values,
+                  )}`,
+      );
+    },
+    onQueryResults: (_query, {text}, results) => {
+      console.log(
+          `${new Date().toISOString()} END QUERY   ${text} - ${
+              results.length} results`,
+      );
+    },
+    onQueryError: (_query, {text}, err) => {
+      console.log(
+          `${new Date().toISOString()} ERROR QUERY ${text} - ${err.message}`,
+      );
+    },
   });
+  console.log('Finished connecting to database...');
+  return pool;
 }
 
 /**
@@ -110,7 +101,7 @@ async function insertRows(
 /**
  * Inserts all rows into the demographics table.
  */
-async function deleteRows(db: Queryable): Promise<any[]>  {
+async function deleteRows(db: Queryable): Promise<any[]> {
   return db.query(sql`DELETE
           FROM demographics
           WHERE census_geo_id IS NOT NULL`);


### PR DESCRIPTION
## Description

Addresses: [https://app.shortcut.com/blueconduit/story/4867/serve-static-census-data-from-postgresql-db-in-aws](Shortcut)

Use databases/pg to write to db instead of AWS's RDS service. Has bulkInsert and helpful formatting helpers. 

## Testing and Reviewing

Using manual test events inside the lambda function. Will follow-up with Gateway call
