### PR TITLE
Give cloudfront function a unique name.

### DIFF
--- a/cdk/src/open-data-platform/frontend/frontend-stack.ts
+++ b/cdk/src/open-data-platform/frontend/frontend-stack.ts
@@ -73,7 +73,7 @@ export class FrontendStack extends Stack {
         // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/monitoring-functions.htmltions/tileServerPrefixTrim?tab=test
         {
           function: new cloudfront.Function(this, 'ViewerResponseFunction', {
-            functionName: 'tileServerPrefixTrim',
+            functionName: `${id}-tileServerPrefixTrim`,
             code: cloudfront.FunctionCode.fromInline(handler.toString()),
             comment: `Trim "${prefixes.tileServer}" prefix from URL`,
           }),


### PR DESCRIPTION
## Description

Addresses: n/a

Previously, the function had a common name that each environment would use. This caused `cdk deploy` to fail. So it now has a unique name.

### New

- n/a

### Changed

- Changed function name.

### Removed

- n/a

## Testing and Reviewing

cdk deploy works and [my function has my own name on it](https://us-east-1.console.aws.amazon.com/cloudfront/v3/home?region=us-east-2#/functions/beekley-OpenDataPlatformFrontend-tileServerPrefixTrim).
