### PR TITLE
Create parcel-level data table.

### DIFF
--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -56,14 +56,13 @@ CREATE INDEX IF NOT EXISTS geom_index
 -- Parcel-level data
 
 CREATE TABLE IF NOT EXISTS parcels (
-    id serial PRIMARY KEY
-);
-ALTER TABLE parcels
+    id serial PRIMARY KEY,
     -- TODO: consider standardizing addresses into a PostGIS type once we have data.
     -- https://postgis.net/docs/manual-2.5/Address_Standardizer.html
-    ADD COLUMN IF NOT EXISTS address text,
-    ADD COLUMN IF NOT EXISTS sl_path geometry(Geometry, 4326),
-    ADD COLUMN IF NOT EXISTS lead_prediction float;
+    address text,
+    sl_path geometry(Geometry, 4326),
+    lead_prediction float
+);
 -- Either of these might be used for searching.
 CREATE INDEX IF NOT EXISTS sl_geometry_index ON parcels USING GIST (sl_path);
 CREATE INDEX IF NOT EXISTS addres_index ON parcels(address);

--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -16,17 +16,11 @@ EXCEPTION
 END;
 $$ LANGUAGE plpgsql;
 
----------------
--- Constants --
----------------
-
-DECLARE
-    -- SRID 4326 maps the shape to latitude and longitude.
-    SRID_LAT_LONG := 4326
-
 ------------
 -- Tables --
 ------------
+
+-- Census-block-level data. TODO: consider renaming the table.
 
 CREATE TABLE IF NOT EXISTS demographics(
     census_geo_id varchar(255) NOT NULL,
@@ -38,12 +32,13 @@ CREATE TABLE IF NOT EXISTS demographics(
 
 ALTER TABLE demographics
     -- SRID 4326 maps the shape to latitude and longitude.
-    ALTER COLUMN geom TYPE GEOMETRY(Geometry, SRID_LAT_LONG);
-
+    ALTER COLUMN geom TYPE GEOMETRY(Geometry, 4326);
 
 CREATE INDEX IF NOT EXISTS geom_index
     ON demographics
     USING GIST (geom);
+
+-- Water-system-level data
 
 CREATE TABLE IF NOT EXISTS water_systems(
     pws_id varchar(255) NOT NULL,
@@ -52,7 +47,7 @@ CREATE TABLE IF NOT EXISTS water_systems(
     );
 
 ALTER TABLE water_systems
-    ADD COLUMN IF NOT EXISTS geom GEOMETRY(Geometry, SRID_LAT_LONG);
+    ADD COLUMN IF NOT EXISTS geom GEOMETRY(Geometry, 4326);
 
 CREATE INDEX IF NOT EXISTS geom_index
     ON water_systems
@@ -67,8 +62,8 @@ ALTER TABLE parcels
     -- TODO: consider standardizing addresses into a PostGIS type once we have data.
     -- https://postgis.net/docs/manual-2.5/Address_Standardizer.html
     ADD COLUMN IF NOT EXISTS address text,
-    ADD COLUMN IF NOT EXISTS sl_path geometry(Geometry, SRID_LAT_LONG),
-    ADD COLUMN IF NOT EXISTS lead_prediction float,
+    ADD COLUMN IF NOT EXISTS sl_path geometry(Geometry, 4326),
+    ADD COLUMN IF NOT EXISTS lead_prediction float;
 -- Either of these might be used for searching.
 CREATE INDEX IF NOT EXISTS sl_geometry_index ON parcels USING GIST (sl_path);
 CREATE INDEX IF NOT EXISTS addres_index ON parcels(address);

--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -67,7 +67,7 @@ ALTER TABLE parcels
     -- TODO: consider standardizing addresses into a PostGIS type once we have data.
     -- https://postgis.net/docs/manual-2.5/Address_Standardizer.html
     ADD COLUMN IF NOT EXISTS address text,
-    ADD COLUMN IF NOT EXISTS sl_path geometry(MultiLineString, SRID_LAT_LONG),
+    ADD COLUMN IF NOT EXISTS sl_path geometry(Geometry, SRID_LAT_LONG),
     ADD COLUMN IF NOT EXISTS lead_prediction float,
 -- Either of these might be used for searching.
 CREATE INDEX IF NOT EXISTS sl_geometry_index ON parcels USING GIST (sl_path);

--- a/cdk/src/resource-initializer.ts
+++ b/cdk/src/resource-initializer.ts
@@ -8,10 +8,8 @@ interface ResourceInitializerProps {
 }
 
 // Construct that invokes a lambda one time during `cdk deploy`.
-
-// If there are other lambdas that we want to invoke during deployment, consider breaking this
-// out into a common file.
-//
+// Note: CDK will consider this "successful" if it is able to invoke the lambda at all, regardless
+// of whether the lambda executed successfully. Check the lambda logs to see its results.
 // Based on: https://github.com/BlueConduit/tributary/blob/main/cdk/lib/resource-initializer.ts
 export class ResourceInitializer extends Construct {
   constructor(scope: Construct, id: string, props: ResourceInitializerProps) {


### PR DESCRIPTION
## Description

Addresses: [Parcel level data in DB](https://app.shortcut.com/blueconduit/story/5146/parcel-level-lsl-prediction-data-for-one-city-is-stored-in-the-db)

Just the table. The lambda that imports data here will come once we have that data. I'm trying to keep PRs short.

### New

- `parcels` table.

### Changed

- Removed the constants, since they weren't working anyway. SQL doesn't let you define constants like that unless it's in a transaction or something.
- Section header comments looks different. I'm not set on this, but wanted to make them stand out more.

### Removed

- n/a

## Testing and Reviewing

n/a
