### PR TITLE
Add DataImportApiStack to import data sources into db via API

### DIFF
--- a/cdk/src/open-data-platform/data-plane/data-import/data-import-api-stack.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/data-import-api-stack.ts
@@ -20,14 +20,15 @@ export class DataImportApiStack extends Construct {
       allowHeaders: ['Content-Type', 'X-Amz-Date', 'Authorization', 'X-Api-Key'],
       allowMethods: ['GET'],
       allowCredentials: true,
+      // TODO(breuch): Limit origins to credentialed users.
       allowOrigins: ['*'],
     },
   });
 
   /**
-   * Adds a lambda integration to the REST api. The endpoint will invoke its
+   * Adds a lambda integration to the REST API. The endpoint will invoke its
    * corresponding lambda
-   * @param endPoint: API endpoint or resource
+   * @param endPoint: API endpoint (Gateway "resource")
    * @param lambdaFunction: function to invoke with /GET request to the endpoint
    */
   addLambdaIntegration(endPoint: string, lambdaFunction: lambda.IFunction): void {

--- a/cdk/src/open-data-platform/data-plane/data-import/data-import-api-stack.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/data-import-api-stack.ts
@@ -1,0 +1,41 @@
+import { Construct } from 'constructs';
+import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+
+/**
+ * Provisions API for data imports.
+ *
+ * Supports lambda integrations in order to invoke functions through its
+ * endpoints.
+ */
+export class DataImportApiStack extends Construct {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+  }
+
+  api = new apigateway.RestApi(this, 'open-data-platform-v1', {
+    restApiName: 'Open Data Platform Service',
+    description: 'Loads available data sources into the database',
+    defaultCorsPreflightOptions: {
+      allowHeaders: ['Content-Type', 'X-Amz-Date', 'Authorization', 'X-Api-Key'],
+      allowMethods: ['GET'],
+      allowCredentials: true,
+      allowOrigins: ['*'],
+    },
+  });
+
+  /**
+   * Adds a lambda integration to the REST api. The endpoint will invoke its
+   * corresponding lambda
+   * @param endPoint: API endpoint or resource
+   * @param lambdaFunction: function to invoke with /GET request to the endpoint
+   */
+  addLambdaIntegration(endPoint: string, lambdaFunction: lambda.IFunction): void {
+    const lambdaIntegration = new apigateway.LambdaIntegration(lambdaFunction, {
+      requestTemplates: { 'application/json': '{ "statusCode": "200" }' },
+    });
+
+    const endpoint = this.api.root.addResource(endPoint);
+    endpoint.addMethod('GET', lambdaIntegration);
+  }
+}

--- a/cdk/src/open-data-platform/data-plane/data-import/data-import-stack.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/data-import-stack.ts
@@ -7,6 +7,7 @@ import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import { Construct } from 'constructs';
 import * as path from 'path';
 import { ResourceInitializer } from '../../../resource-initializer';
+import { DataImportApiStack } from './data-import-api-stack';
 
 interface SchemaProps {
   cluster: rds.ServerlessCluster;
@@ -87,6 +88,10 @@ export class DataImportStack extends Construct {
         cluster.grantDataApiAccess(role);
       }
     }
+
+    const dataImportApiStack = new DataImportApiStack(this, 'DataImportApiStack');
+    dataImportApiStack.addLambdaIntegration('waterSystems', writeWaterSystemsDataFunction);
+    dataImportApiStack.addLambdaIntegration('demographics', writeDemographicDataFunction);
 
     // Import the data on CDK deploy.
     // TODO: enable this once it is ready to use.


### PR DESCRIPTION
## Description

Addresses: [Initialize API](https://app.shortcut.com/blueconduit/story/3679/initialize-api)

Adds Stack to provision REST API for data imports. Adds lambda integrations such that endpoints can invoke lambda functions.

Considering changing process.env variables in lambda to query parameters (in separate PR)

### New

DataImportApiStack

## Testing and Reviewing

AWS console test events
