### PR TITLE
Add lambda handler to write into epa_violations table 

### DIFF
--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -15,6 +15,7 @@
         "aws-sdk": "^2.1148.0",
         "constructs": "^10.0.0",
         "csv-parser": "^3.0.0",
+        "moment": "^2.29.3",
         "source-map-support": "^0.5.16",
         "stream-chain": "^2.2.5",
         "stream-json": "^1.7.4"
@@ -6480,6 +6481,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
+      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -13745,6 +13754,11 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
+    },
+    "moment": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
+      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw=="
     },
     "ms": {
       "version": "2.1.2",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -29,6 +29,7 @@
     "aws-sdk": "^2.1148.0",
     "constructs": "^10.0.0",
     "csv-parser": "^3.0.0",
+    "moment": "^2.29.3",
     "source-map-support": "^0.5.16",
     "stream-chain": "^2.2.5",
     "stream-json": "^1.7.4"

--- a/cdk/src/open-data-platform/data-plane/data-import/data-import-stack.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/data-import-stack.ts
@@ -33,7 +33,8 @@ export class DataImportStack extends Construct {
           CREDENTIALS_SECRET: credentialsSecret.secretArn,
           DATABASE_NAME: db,
         },
-        timeout: Duration.minutes(5),
+        memorySize: 512,
+        timeout: Duration.minutes(15),
         bundling: {
           externalModules: ['aws-sdk'],
           nodeModules: ['csv-parser', '@databases/pg'],
@@ -53,10 +54,32 @@ export class DataImportStack extends Construct {
           CREDENTIALS_SECRET: credentialsSecret.secretArn,
           DATABASE_NAME: db,
         },
-        timeout: Duration.minutes(5),
+        memorySize: 512,
+        timeout: Duration.minutes(15),
         bundling: {
           externalModules: ['aws-sdk'],
           nodeModules: ['stream-json', '@databases/pg', 'stream-chain'],
+        },
+      },
+    );
+
+    const writeViolationsDataFunction = new lambda.NodejsFunction(
+      this,
+      'write-violations-data-handler',
+      {
+        entry: `${path.resolve(__dirname)}/write-violations-data.handler.ts`,
+        handler: 'handler',
+        vpc: vpc,
+        vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_NAT },
+        environment: {
+          CREDENTIALS_SECRET: credentialsSecret.secretArn,
+          DATABASE_NAME: db,
+        },
+        memorySize: 512,
+        timeout: Duration.minutes(15),
+        bundling: {
+          externalModules: ['aws-sdk'],
+          nodeModules: ['stream-json', '@databases/pg'],
         },
       },
     );
@@ -74,6 +97,7 @@ export class DataImportStack extends Construct {
     const lambda_functions: lambda.NodejsFunction[] = [
       writeDemographicDataFunction,
       writeWaterSystemsDataFunction,
+      writeViolationsDataFunction,
     ];
 
     for (let f of lambda_functions) {

--- a/cdk/src/open-data-platform/data-plane/data-import/data-import-stack.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/data-import-stack.ts
@@ -79,7 +79,7 @@ export class DataImportStack extends Construct {
         timeout: Duration.minutes(15),
         bundling: {
           externalModules: ['aws-sdk'],
-          nodeModules: ['stream-json', '@databases/pg'],
+          nodeModules: ['stream-json', '@databases/pg', 'moment'],
         },
       },
     );

--- a/cdk/src/open-data-platform/data-plane/data-import/write-violations-data.handler.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/write-violations-data.handler.ts
@@ -71,7 +71,7 @@ async function deleteRows(db: ConnectionPool): Promise<any[]> {
 /**
  * Reads the S3 CSV file and the number of rows successfully written.
  */
-function parseS3IntoLeadServiceLinesTableRow(
+function parseS3IntoViolationsTableRow(
   s3Params: AWS.S3.GetObjectRequest,
   db: ConnectionPool,
   numberOfRowsToWrite = DEFAULT_NUMBER_ROWS_TO_INSERT,
@@ -165,7 +165,7 @@ export async function handler(_: APIGatewayProxyEvent): Promise<APIGatewayProxyR
 
     // Remove existing rows before inserting new ones.
     await deleteRows(db);
-    const numberRows = await parseS3IntoLeadServiceLinesTableRow(s3Params, db, numberRowsToWrite);
+    const numberRows = await parseS3IntoViolationsTableRow(s3Params, db, numberRowsToWrite);
     return {
       statusCode: 200,
       body: JSON.stringify({ 'Added rows': numberRows }),

--- a/cdk/src/open-data-platform/data-plane/data-import/write-violations-data.handler.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/write-violations-data.handler.ts
@@ -1,0 +1,254 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { ConnectionPool, sql } from '@databases/pg';
+import * as AWS from 'aws-sdk';
+import { connectToDb } from '../schema/schema.handler';
+
+const { chain } = require('stream-chain');
+const { streamArray } = require('stream-json/streamers/StreamArray');
+const Batch = require('stream-json/utils/Batch');
+const Pick = require('stream-json/filters/Pick');
+
+const S3 = new AWS.S3();
+
+const DEFAULT_NUMBER_ROWS_TO_INSERT = 10;
+
+const VIOLATION = 'SDWISDM.VIOLATION';
+const VIOLATION_ID = `${VIOLATION}.VIOLATION_ID`;
+const PWSID = `${VIOLATION}.VIOLATION_ID`;
+const VIOLATION_CODE = `${VIOLATION}.VIOLATION_CODE`;
+const COMPLIANCE_STATUS_CODE = `${VIOLATION}.COMPLIANCE_STATUS_CODE`;
+const COMPL_PER_BEGIN_DATE = `${VIOLATION}.COMPL_PER_BEGIN_DATE`;
+
+/**
+ * See https://www.epa.gov/sites/default/files/2019-07/documents/environments-and-contaminants-methods-drinking-water.pdf
+ * Page 4.
+ */
+const LEAD_AND_COPPER_VIOLATIONS = new Set(['57', '58', '59', '63', '65']);
+
+/**
+ * According to EPA officials, “known” means the violation is not open but
+ * the system has not yet been designated as returned to compliance.
+ */
+const COMPLIANCE_STATUS_MAP = new Map([
+  ['K', 'Known'],
+  ['O', 'Open'],
+]);
+
+/**
+ * Inserts all rows into the violations table.
+ */
+async function insertRows(db: ConnectionPool, rows: ViolationsTableRow[]): Promise<any[]> {
+  return db.query(sql`INSERT INTO epa_violation (violation_id,
+                                                 pws_id,
+                                                 violation_code,
+                                                 compliance_status_code,
+                                                 start_date)
+                      VALUES ${sql.join(
+                        rows.map((row: ViolationsTableRow) => {
+                          return sql`(${row.violation_id}, 
+                                      ${row.pws_id}, 
+                                      ${row.violation_code}, 
+                                      ${row.compliance_status}, 
+                                      ${row.start_date},
+                                      ${sql.__dangerous__rawValue(
+                                        `ST_AsText(ST_GeomFromGeoJSON('${row.geom}'))`,
+                                      )})`;
+                        }),
+                        ',',
+                      )};`);
+}
+
+/**
+ * Inserts all rows into the violations table.
+ */
+async function deleteRows(db: ConnectionPool): Promise<any[]> {
+  return db.query(sql`DELETE
+                      FROM water_systems
+                      WHERE pws_id IS NOT NULL`);
+}
+
+/**
+ * Reads the S3 CSV file and the number of rows successfully written.
+ */
+function parseS3IntoLeadServiceLinesTableRow(
+  s3Params: AWS.S3.GetObjectRequest,
+  db: ConnectionPool,
+  numberOfRowsToWrite = DEFAULT_NUMBER_ROWS_TO_INSERT,
+): Promise<number> {
+  return new Promise(function (resolve, reject) {
+    const batchSize = 10;
+    let numberRows = 0;
+    let results: ViolationsTableRow[] = [];
+
+    const fileStream = S3.getObject(s3Params).createReadStream();
+    let pipeline = chain([
+      fileStream,
+      Pick.withParser({ filter: 'features' }),
+      streamArray(),
+      new Batch({ batchSize: batchSize }),
+    ]);
+
+    pipeline
+      .on('data', async (batch: any[]) => {
+        if (numberRows < numberOfRowsToWrite) {
+          for (const data of batch) {
+            console.log(data);
+            if (data[VIOLATION_CODE] in LEAD_AND_COPPER_VIOLATIONS) {
+              const row = new ViolationsTableRowBuilder()
+                .violationId(data[VIOLATION_ID])
+                .pwsId(data[PWSID])
+                .violationCode(data[VIOLATION_CODE])
+                .complianceStatus(COMPLIANCE_STATUS_MAP.get(data[COMPLIANCE_STATUS_CODE]) ?? '')
+                .startDate(data[COMPL_PER_BEGIN_DATE])
+                .geom('')
+                .build();
+              results.push(row);
+
+              numberRows++;
+
+              // Every batch size, write into the db.
+              if (results.length == batchSize) {
+                // Pause reads while inserting into db.
+                fileStream.pause();
+                await insertRows(db, results);
+                results = [];
+                fileStream.resume();
+              }
+            }
+          }
+        } else {
+          // Stop reading stream if numberOfRowsToWrite has been met.
+          fileStream.destroy();
+        }
+      })
+      .on('error', (error: Error) => {
+        reject(error);
+      })
+      // Gets called by pipeline.destroy()
+      .on('close', async (_: Error) => {
+        resolve(numberRows);
+      })
+      .on('end', async () => {
+        resolve(numberRows);
+      });
+  });
+}
+
+/**
+ * Parses S3 'violations_by_water_system.csv' file and writes rows
+ * to violations table in the MainCluster postgres db.
+ */
+export async function handler(_: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  const numberRowsToWrite: number = parseInt(
+    process.env.numberRows ?? `${DEFAULT_NUMBER_ROWS_TO_INSERT}`,
+  );
+
+  const s3Params = {
+    Bucket: 'opendataplatformapistaticdata',
+    Key: 'violations_with_geom.geojson',
+  };
+
+  let db: ConnectionPool | undefined;
+
+  // Read CSV file and write to violations table.
+  try {
+    db = await connectToDb();
+    if (db == undefined) {
+      throw Error('Unable to connect to db');
+    }
+
+    // Remove existing rows before inserting new ones.
+    await deleteRows(db);
+    const numberRows = await parseS3IntoLeadServiceLinesTableRow(s3Params, db, numberRowsToWrite);
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ 'Added rows': numberRows }),
+    };
+  } catch (error) {
+    console.log('Error:' + error);
+    throw error;
+  } finally {
+    console.log('Disconnecting from db...');
+    await db?.dispose();
+  }
+}
+
+/**
+ * Single row for violations table.
+ */
+class ViolationsTableRow {
+  // Field formatting conforms to rows in the db. Requires less transformations.
+
+  // Water system identifier.
+  violation_id: string;
+  // Water system identifier.
+  pws_id: string;
+  // Code for the violation.
+  violation_code: string;
+  // Status of violation.
+  compliance_status: string;
+  // Date the violation began in the form of YYYY-mm-dd.
+  start_date: string;
+  // GeoJSON representation of the boundaries.
+  geom: string;
+
+  constructor(
+    pws_id: string,
+    violation_id: string,
+    violation_code: string,
+    compliance_status: string,
+    start_date: string,
+    geom: string,
+  ) {
+    this.pws_id = pws_id;
+    this.violation_id = violation_id;
+    this.violation_code = violation_code;
+    this.start_date = start_date;
+    this.geom = geom;
+  }
+}
+
+/**
+ * Builder utility for rows of the violations table.
+ */
+class ViolationsTableRowBuilder {
+  private readonly _row: ViolationsTableRow;
+
+  constructor() {
+    this._row = new ViolationsTableRow('', '', '', '', '', '');
+  }
+
+  violationId(violationId: string): ViolationsTableRowBuilder {
+    this._row.violation_id = violationId;
+    return this;
+  }
+
+  pwsId(pwsId: string): ViolationsTableRowBuilder {
+    this._row.pws_id = pwsId;
+    return this;
+  }
+
+  violationCode(violationCode: string): ViolationsTableRowBuilder {
+    this._row.violation_code = violationCode;
+    return this;
+  }
+
+  complianceStatus(complianceStatus: string): ViolationsTableRowBuilder {
+    this._row.compliance_status = complianceStatus;
+    return this;
+  }
+
+  startDate(startDate: string): ViolationsTableRowBuilder {
+    this._row.start_date = startDate;
+    return this;
+  }
+
+  geom(geom: string): ViolationsTableRowBuilder {
+    this._row.geom = geom;
+    return this;
+  }
+
+  build(): ViolationsTableRow {
+    return this._row;
+  }
+}

--- a/cdk/src/open-data-platform/data-plane/data-import/write-water-systems-data-handler.handler.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/write-water-systems-data-handler.handler.ts
@@ -1,5 +1,5 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
-import { ConnectionPool, Queryable, sql } from '@databases/pg';
+import { ConnectionPool, sql } from '@databases/pg';
 import * as AWS from 'aws-sdk';
 import { connectToDb } from '../schema/schema.handler';
 

--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -55,19 +55,9 @@ CREATE TABLE IF NOT EXISTS epa_violations(
     violation_code varchar(255) NOT NULL,
     compliance_status varchar(255) NOT NULL,
     start_date DATE NOT NULL,
-    pws_id varchar(255) NOT NULL,
-    geom GEOMETRY(Geometry, 4326),
+    pws_id varchar(255) NOT NULL REFERENCES water_systems(pws_id),
     PRIMARY KEY(violation_id)
     );
-
-CREATE INDEX IF NOT EXISTS geom_index
-    ON epa_violations
-    USING GIST (geom);
-
--- Ensure faster reads on PWS id --
-CREATE INDEX IF NOT EXISTS pws_id_index
-    ON epa_violations
-    USING GIST (pws_id);
 
 -- Parcel-level data
 


### PR DESCRIPTION
## Description

Addresses: [Display EPA violations data on the map](https://app.shortcut.com/blueconduit/story/5481/display-epa-violations-data-on-the-map)

Adds the writeViolationsDataFunction which reads from a static file in s3 and writes to the epa_violations table. 
This information is only available at the water system level, so we may want to consider moving it to water systems eventually but I think for now keeping this separate it best for simplicity. 

### New

Data handler for the lambda function 

### Changed

Schema.sql creates the epa_violations table if it does not exist. 

## Testing and Reviewing

Test events in AWS console
