### PR TITLE
Fix water systems and epa violations handlers to write all rows

### DIFF
--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -11,6 +11,7 @@
         "@aws-cdk/aws-lambda": "^1.156.1",
         "@aws-sdk/client-secrets-manager": "^3.92.0",
         "@databases/pg": "^5.4.1",
+        "@types/pg": "^8.6.5",
         "aws-cdk-lib": "2.21.1",
         "aws-sdk": "^2.1148.0",
         "constructs": "^10.0.0",
@@ -18,6 +19,7 @@
         "moment": "^2.29.3",
         "pg": "^8.7.3",
         "pg-format": "^1.0.4",
+        "simdjson": "^0.9.2",
         "source-map-support": "^0.5.16",
         "stream-chain": "^2.2.5",
         "stream-json": "^1.7.4"
@@ -6543,6 +6545,11 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node_modules/node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -7758,6 +7765,15 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/simdjson": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/simdjson/-/simdjson-0.9.2.tgz",
+      "integrity": "sha512-CW97acb8ty4EcxJGsCTrgxh1iiqLKbcuaIAte4DjPdoytK2ps1cRN1HpBJjIzqaL5cn1m/Dqc4AqA6NlKPPKKA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-addon-api": "^2.0.0"
+      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -13826,6 +13842,11 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -14766,6 +14787,14 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "simdjson": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/simdjson/-/simdjson-0.9.2.tgz",
+      "integrity": "sha512-CW97acb8ty4EcxJGsCTrgxh1iiqLKbcuaIAte4DjPdoytK2ps1cRN1HpBJjIzqaL5cn1m/Dqc4AqA6NlKPPKKA==",
+      "requires": {
+        "node-addon-api": "^2.0.0"
+      }
     },
     "sisteransi": {
       "version": "1.0.5",

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -11,11 +11,14 @@
         "@aws-cdk/aws-lambda": "^1.156.1",
         "@aws-sdk/client-secrets-manager": "^3.92.0",
         "@databases/pg": "^5.4.1",
+        "@types/pg": "^8.6.5",
         "aws-cdk-lib": "2.21.1",
         "aws-sdk": "^2.1148.0",
         "constructs": "^10.0.0",
         "csv-parser": "^3.0.0",
         "moment": "^2.29.3",
+        "pg": "^8.7.3",
+        "pg-format": "^1.0.4",
         "source-map-support": "^0.5.16",
         "stream-chain": "^2.2.5",
         "stream-json": "^1.7.4"
@@ -2846,14 +2849,23 @@
     "node_modules/@types/node": {
       "version": "10.17.27",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.27.tgz",
-      "integrity": "sha512-J0oqm9ZfAXaPdwNXMMgAhylw5fhmXkToJd06vuDUSAgEDZ/n/69/69UmyBZbc+zT34UnShuDSBqvim3SPnozJg==",
-      "dev": true
+      "integrity": "sha512-J0oqm9ZfAXaPdwNXMMgAhylw5fhmXkToJd06vuDUSAgEDZ/n/69/69UmyBZbc+zT34UnShuDSBqvim3SPnozJg=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
+    },
+    "node_modules/@types/pg": {
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.5.tgz",
+      "integrity": "sha512-tOkGtAqRVkHa/PVZicq67zuujI4Oorfglsr2IbKofDwBSysnaqSx7W1mDqFqdkGE6Fbgh+PZAl0r/BWON/mozw==",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
     },
     "node_modules/@types/prettier": {
       "version": "2.6.0",
@@ -6937,6 +6949,14 @@
       "integrity": "sha512-vmjXRMD4jZK/oHaaYk6clTypgHNlzCCAqyLCO5d/UeI42egJVE5H4ZfZWACub3jzkHUXXyvibH207zAJg9iBOw==",
       "peerDependencies": {
         "pg": "^8"
+      }
+    },
+    "node_modules/pg-format": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pg-format/-/pg-format-1.0.4.tgz",
+      "integrity": "sha512-YyKEF78pEA6wwTAqOUaHIN/rWpfzzIuMh9KdAhc3rSLQ/7zkRFcCgYBAEGatDstLyZw4g0s9SNICmaTGnBVeyw==",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/pg-int8": {
@@ -11099,14 +11119,23 @@
     "@types/node": {
       "version": "10.17.27",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.27.tgz",
-      "integrity": "sha512-J0oqm9ZfAXaPdwNXMMgAhylw5fhmXkToJd06vuDUSAgEDZ/n/69/69UmyBZbc+zT34UnShuDSBqvim3SPnozJg==",
-      "dev": true
+      "integrity": "sha512-J0oqm9ZfAXaPdwNXMMgAhylw5fhmXkToJd06vuDUSAgEDZ/n/69/69UmyBZbc+zT34UnShuDSBqvim3SPnozJg=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
+    },
+    "@types/pg": {
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.5.tgz",
+      "integrity": "sha512-tOkGtAqRVkHa/PVZicq67zuujI4Oorfglsr2IbKofDwBSysnaqSx7W1mDqFqdkGE6Fbgh+PZAl0r/BWON/mozw==",
+      "requires": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
     },
     "@types/prettier": {
       "version": "2.6.0",
@@ -14109,6 +14138,11 @@
       "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.7.3.tgz",
       "integrity": "sha512-vmjXRMD4jZK/oHaaYk6clTypgHNlzCCAqyLCO5d/UeI42egJVE5H4ZfZWACub3jzkHUXXyvibH207zAJg9iBOw==",
       "requires": {}
+    },
+    "pg-format": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pg-format/-/pg-format-1.0.4.tgz",
+      "integrity": "sha512-YyKEF78pEA6wwTAqOUaHIN/rWpfzzIuMh9KdAhc3rSLQ/7zkRFcCgYBAEGatDstLyZw4g0s9SNICmaTGnBVeyw=="
     },
     "pg-int8": {
       "version": "1.0.1",

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -11,7 +11,6 @@
         "@aws-cdk/aws-lambda": "^1.156.1",
         "@aws-sdk/client-secrets-manager": "^3.92.0",
         "@databases/pg": "^5.4.1",
-        "@types/pg": "^8.6.5",
         "aws-cdk-lib": "2.21.1",
         "aws-sdk": "^2.1148.0",
         "constructs": "^10.0.0",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -11,8 +11,8 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@types/aws-lambda": "^8.10.97",
     "@aws-sdk/types": "^3.78.0",
+    "@types/aws-lambda": "^8.10.97",
     "@types/jest": "^26.0.10",
     "@types/node": "^10.17.27",
     "aws-cdk": "2.21.1",
@@ -26,11 +26,14 @@
     "@aws-cdk/aws-lambda": "^1.156.1",
     "@aws-sdk/client-secrets-manager": "^3.92.0",
     "@databases/pg": "^5.4.1",
+    "@types/pg": "^8.6.5",
     "aws-cdk-lib": "2.21.1",
     "aws-sdk": "^2.1148.0",
     "constructs": "^10.0.0",
     "csv-parser": "^3.0.0",
     "moment": "^2.29.3",
+    "pg": "^8.7.3",
+    "pg-format": "^1.0.4",
     "source-map-support": "^0.5.16",
     "stream-chain": "^2.2.5",
     "stream-json": "^1.7.4"

--- a/cdk/src/open-data-platform/data-plane/data-import/data-import-stack.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/data-import-stack.ts
@@ -58,7 +58,7 @@ export class DataImportStack extends Construct {
         timeout: Duration.minutes(15),
         bundling: {
           externalModules: ['aws-sdk'],
-          nodeModules: ['stream-json', 'pg', '@types/pg', 'stream-chain', 'pg-format'],
+          nodeModules: ['stream-json', 'stream-chain', 'pg', 'pg-format'],
         },
       },
     );
@@ -79,7 +79,7 @@ export class DataImportStack extends Construct {
         timeout: Duration.minutes(15),
         bundling: {
           externalModules: ['aws-sdk'],
-          nodeModules: ['stream-json', 'pg', 'pg-format', 'moment'],
+          nodeModules: ['stream-json', 'stream-chain', 'pg', 'pg-format', 'moment'],
         },
       },
     );

--- a/cdk/src/open-data-platform/data-plane/data-import/data-import-stack.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/data-import-stack.ts
@@ -58,7 +58,7 @@ export class DataImportStack extends Construct {
         timeout: Duration.minutes(15),
         bundling: {
           externalModules: ['aws-sdk'],
-          nodeModules: ['stream-json', '@databases/pg', 'stream-chain'],
+          nodeModules: ['stream-json', 'pg', '@types/pg', 'stream-chain', 'pg-format'],
         },
       },
     );
@@ -79,7 +79,7 @@ export class DataImportStack extends Construct {
         timeout: Duration.minutes(15),
         bundling: {
           externalModules: ['aws-sdk'],
-          nodeModules: ['stream-json', '@databases/pg', 'moment'],
+          nodeModules: ['stream-json', 'pg', 'pg-format', 'moment'],
         },
       },
     );

--- a/cdk/src/open-data-platform/data-plane/data-import/write-violations-data.handler.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/write-violations-data.handler.ts
@@ -89,7 +89,7 @@ function parseS3IntoViolationsTableRow(
   numberOfRowsToWrite = DEFAULT_NUMBER_ROWS_TO_INSERT,
 ): Promise<number> {
   return new Promise(async function (resolve, reject) {
-    const batchSize = 10000;
+    const batchSize = 2500;
     let numberRowsParsed = 0;
     const promises: Promise<QueryArrayResult>[] = [];
 

--- a/cdk/src/open-data-platform/data-plane/data-import/write-water-systems-data-handler.handler.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/write-water-systems-data-handler.handler.ts
@@ -20,10 +20,10 @@ const Batch = require('stream-json/utils/Batch');
 
 // Number of rows to write at once.
 const BATCH_SIZE = 10;
+const DEFAULT_NUMBER_ROWS_TO_INSERT = 10000;
 const RESOURCE_ARN = process.env.RESOURCE_ARN ?? '';
 
 const S3 = new AWS.S3();
-const DEFAULT_NUMBER_ROWS_TO_INSERT = 10000;
 
 /**
  *  Writes rows into the water systems table.

--- a/cdk/src/open-data-platform/data-plane/data-import/write-water-systems-data-handler.handler.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/write-water-systems-data-handler.handler.ts
@@ -143,10 +143,8 @@ async function parseS3IntoLeadServiceLinesTableRow(
 /**
  * Writes the table rows to the db and adds execution to list of promises.
  *
- * @param dbConfig: Configs to use for connecting to the db.
  * @param rdsDataService: RDS service to connect to the db.
  * @param tableRows: Rows to write to the db.
- * @param promises: List of promises collecting db executions.
  */
 function executeBatchOfRows(
   rdsDataService: RDSDataService,

--- a/cdk/src/open-data-platform/data-plane/data-import/write-water-systems-data-handler.handler.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/write-water-systems-data-handler.handler.ts
@@ -37,12 +37,10 @@ async function insertRows(db: PoolClient, rows: WaterSystemsTableRow[]): Promise
     'VALUES %s ON CONFLICT (pws_id) DO NOTHING';
 
   try {
-    await db.query('BEGIN');
     const queryResult = await db.query(format(insertIntoStatement, valuesToInsert), []);
-    await db.query('COMMIT');
     return queryResult;
   } catch (error) {
-    await db.query('ROLLBACK');
+    console.log(`Error in writing rows to db ${error}`);
     throw error;
   }
 }
@@ -61,7 +59,7 @@ async function parseS3IntoLeadServiceLinesTableRow(
   numberOfRowsToWrite = DEFAULT_NUMBER_ROWS_TO_INSERT,
 ): Promise<number> {
   return new Promise(function (resolve, reject) {
-    const batchSize = 10000;
+    const batchSize = 10;
     let numberRowsParsed = 0;
     const promises: Promise<QueryArrayResult>[] = [];
 

--- a/cdk/src/open-data-platform/data-plane/data-import/write-water-systems-data-handler.handler.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/write-water-systems-data-handler.handler.ts
@@ -116,7 +116,6 @@ async function parseS3IntoLeadServiceLinesTableRow(
 
           promises.push(executeBatchOfRows(rdsDataService, tableRows));
           numberRowsParsed += rows.length;
-          console.log(`Parsed ${numberRowsParsed} rows`);
 
           // Stop reading stream if numberOfRowsToWrite has been met.
           if (numberRowsParsed >= endIndex) {
@@ -204,6 +203,7 @@ export async function handler(_: APIGatewayProxyEvent): Promise<APIGatewayProxyR
       0,
       numberRowsToWrite,
     );
+    console.log(`Parsed ${numberRows} rows`);
 
     return {
       statusCode: 200,

--- a/cdk/src/open-data-platform/data-plane/schema/schema.handler.ts
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.handler.ts
@@ -4,6 +4,7 @@
 
 import createConnectionPool, { ConnectionPool, ConnectionPoolConfig, sql } from '@databases/pg';
 import { SecretsManager } from '@aws-sdk/client-secrets-manager';
+import { throws } from 'assert';
 
 const CREDENTIALS_SECRET = process.env.CREDENTIALS_SECRET ?? '';
 const DATABASE_NAME = process.env.DATABASE_NAME ?? '';
@@ -112,7 +113,7 @@ async function runSchemaFile(file: string, db: ConnectionPool) {
 /**
  * Fetches database credentials based on the CREDENTIALS_SECRET
  */
-async function createDatabaseConfig(): Promise<ConnectionPoolConfig> {
+export async function createDatabaseConfig(): Promise<ConnectionPoolConfig> {
   console.log('Fetching db credentials...');
   const { host, port, username, password } = await getCredentials(CREDENTIALS_SECRET);
   return {
@@ -157,5 +158,7 @@ export function database(config: ConnectionPoolConfig): ConnectionPool {
     onQueryError: (_query: any, { text }, err) => {
       console.log(`${new Date().toISOString()} ERROR QUERY ${text} - ${err.message}`);
     },
+    idleTimeoutMilliseconds: 0,
+    ssl: { rejectUnauthorized: false },
   });
 }

--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS demographics(
     total_population real,
     black_percentage real,
     white_percentage real,
-    geom TYPE GEOMETRY(Geometry, 4326)
+    geom GEOMETRY(Geometry, 4326),
     PRIMARY KEY(census_geo_id)
 );
 
@@ -39,7 +39,10 @@ CREATE INDEX IF NOT EXISTS geom_index
 
 CREATE TABLE IF NOT EXISTS water_systems(
     pws_id varchar(255) NOT NULL,
+    pws_name varchar(255),
     lead_connections_count real,
+    service_connections_count real,
+    population_served real,
     geom GEOMETRY(Geometry, 4326),
     PRIMARY KEY(pws_id)
     );

--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -55,9 +55,20 @@ CREATE TABLE IF NOT EXISTS epa_violations(
     violation_code varchar(255) NOT NULL,
     compliance_status varchar(255) NOT NULL,
     start_date DATE NOT NULL,
+    end_date DATE NOT NULL,
     pws_id varchar(255) NOT NULL REFERENCES water_systems(pws_id),
     PRIMARY KEY(violation_id)
     );
+
+-- Violation counts --
+CREATE VIEW violation_counts AS
+SELECT
+    pws_id,
+    geom,
+    COUNT(violation_id)
+FROM epa_violations
+JOIN water_systems USING (pws_id)
+GROUP BY pws_id, geom;
 
 -- Parcel-level data
 

--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -68,7 +68,7 @@ CREATE VIEW violation_counts AS
 SELECT
     pws_id,
     geom,
-    COUNT(violation_id)
+    COUNT(violation_id) AS violation_count
 FROM epa_violations
 JOIN water_systems USING (pws_id)
 GROUP BY pws_id, geom;

--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -64,6 +64,7 @@ CREATE TABLE IF NOT EXISTS epa_violations(
     );
 
 -- Violation counts per water system --
+
 CREATE VIEW violation_counts AS
 SELECT
     pws_id,

--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -63,7 +63,7 @@ CREATE TABLE IF NOT EXISTS epa_violations(
     PRIMARY KEY(violation_id)
     );
 
--- Violation counts --
+-- Violation counts per water system --
 CREATE VIEW violation_counts AS
 SELECT
     pws_id,

--- a/cdk/tsconfig.json
+++ b/cdk/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "lib": [
       "es2018",
+      // Need this for Promise.allSettled()
       "ES2020.Promise"
     ],
     "declaration": true,

--- a/cdk/tsconfig.json
+++ b/cdk/tsconfig.json
@@ -3,7 +3,8 @@
     "target": "ES2018",
     "module": "commonjs",
     "lib": [
-      "es2018"
+      "es2018",
+      "ES2020.Promise"
     ],
     "declaration": true,
     "strict": true,


### PR DESCRIPTION
Fix water systems and epa violations handlers to write all rows

## Description

Addresses: [Display EPA violations data on the map](https://app.shortcut.com/blueconduit/story/5481/display-epa-violations-data-on-the-map)

Updates both water systems and violations data handlers to use a new better-supported library for writing to the db (pg not @databases/pg).

Allows passing in start index for writing rows to make it easier to run this lambda multiple times without too much editing.

With both handlers fixed, I could create a violations_count view that aggregated violations at the water system level. 

### New

New view inside schema.sql

### Changed

Both handlers have been updated and refactored. 

### Removed

Use of @database/pg

## Testing and Reviewing

AWS test events
