### PR TITLE
Add toledo parcel data to parcels table

### DIFF
--- a/cdk/src/open-data-platform/data-plane/data-import/data-import-stack.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/data-import-stack.ts
@@ -93,11 +93,13 @@ export class DataImportStack extends Construct {
       environment: {
         CREDENTIALS_SECRET: credentialsSecret.secretArn,
         DATABASE_NAME: db,
+        RESOURCE_ARN:
+          'arn:aws:rds:us-east-2:036999211278:cluster:breuch-opendataplatformdatapl-maincluster834123e8-wxi60mcf08md',
       },
       timeout: Duration.minutes(5),
       bundling: {
         externalModules: ['aws-sdk'],
-        nodeModules: ['stream-json', '@databases/pg', 'stream-chain'],
+        nodeModules: ['stream-json', 'stream-chain'],
       },
     });
 

--- a/cdk/src/open-data-platform/data-plane/data-import/data-import-stack.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/data-import-stack.ts
@@ -54,6 +54,7 @@ export class DataImportStack extends Construct {
         environment: {
           CREDENTIALS_SECRET: credentialsSecret.secretArn,
           DATABASE_NAME: db,
+          RESOURCE_ARN: cluster.clusterArn,
         },
         memorySize: 512,
         timeout: Duration.minutes(15),
@@ -93,6 +94,7 @@ export class DataImportStack extends Construct {
       environment: {
         CREDENTIALS_SECRET: credentialsSecret.secretArn,
         DATABASE_NAME: db,
+        RESOURCE_ARN: cluster.clusterArn,
       },
       timeout: Duration.minutes(5),
       bundling: {

--- a/cdk/src/open-data-platform/data-plane/data-import/data-import-stack.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/data-import-stack.ts
@@ -93,8 +93,6 @@ export class DataImportStack extends Construct {
       environment: {
         CREDENTIALS_SECRET: credentialsSecret.secretArn,
         DATABASE_NAME: db,
-        RESOURCE_ARN:
-          'arn:aws:rds:us-east-2:036999211278:cluster:breuch-opendataplatformdatapl-maincluster834123e8-wxi60mcf08md',
       },
       timeout: Duration.minutes(5),
       bundling: {

--- a/cdk/src/open-data-platform/data-plane/data-import/write-parcels-data.handler.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/write-parcels-data.handler.ts
@@ -113,12 +113,11 @@ async function writeS3FileToTable(
           let tableRows: SqlParametersList[] = [];
           const shouldWriteRows = numberRowsParsed >= startIndex && numberRowsParsed <= endIndex;
           if (shouldWriteRows) {
-            tableRows = rows.reduce(function (result, row) {
+            for (const row of rows) {
               if (row.value.properties.address != '' && row.value.properties.address != null) {
-                result.push(getTableRowFromRow(row));
+                tableRows.push(getTableRowFromRow(row));
               }
-              return result;
-            }, []);
+            }
           }
 
           promises.push(executeBatchOfRows(rdsDataService, tableRows));

--- a/cdk/src/open-data-platform/data-plane/data-import/write-parcels-data.handler.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/write-parcels-data.handler.ts
@@ -1,15 +1,215 @@
-import { ConnectionPool } from '@databases/pg';
-import { geoJsonHandlerFactory } from './handler-factory';
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import * as AWS from 'aws-sdk';
+import { RDSDataService } from 'aws-sdk';
+import {
+  BatchExecuteStatementRequest,
+  BatchExecuteStatementResponse,
+  SqlParametersList,
+} from 'aws-sdk/clients/rdsdataservice';
+import { ParcelsTableRowBuilder } from '../model/parcel_table';
 
-const s3Params = {
-  Bucket: 'opendataplatformapistaticdata',
-  Key: 'toledo_parcel_preds.geojson',
-};
+const { chain } = require('stream-chain');
+const { ignore } = require('stream-json/filters/Ignore');
+const { pick } = require('stream-json/filters/Pick');
+const { parser } = require('stream-json/Parser');
+const { streamArray } = require('stream-json/streamers/StreamArray');
+const Batch = require('stream-json/utils/Batch');
 
-export const handler = geoJsonHandlerFactory(
-  s3Params,
-  async (row: any, _: ConnectionPool) => {
-    console.log('Row:', row);
-  },
-  20, // limit to 20 rows for testing.
-);
+// Number of rows to write at once.
+const BATCH_SIZE = 10;
+const DEFAULT_NUMBER_ROWS_TO_INSERT = 10000;
+const SCHEMA = 'schema';
+
+const S3 = new AWS.S3();
+
+/**
+ *  Writes rows into the parcel table.
+ * @param rdsService: RDS service to connect to the db.
+ * @param rows: Rows to write to the db.
+ */
+async function insertBatch(
+  rdsService: RDSDataService,
+  rows: SqlParametersList[],
+): Promise<RDSDataService.BatchExecuteStatementResponse> {
+  const batchExecuteParams: BatchExecuteStatementRequest = {
+    database: process.env.DATABASE_NAME ?? 'postgres',
+    parameterSets: rows,
+    resourceArn: process.env.RESOURCE_ARN ?? '',
+    schema: SCHEMA,
+    secretArn: process.env.CREDENTIALS_SECRET ?? '',
+    sql: `INSERT INTO parcels (address,
+                               public_lead_prediction,
+                               private_lead_prediction,
+                               geom)
+          VALUES (:address,
+                  :public_lead_prediction,
+                  :private_lead_prediction,
+                  ST_AsText(ST_GeomFromGeoJSON(:geom))) ON CONFLICT (address) DO NOTHING`,
+  };
+  return rdsService.batchExecuteStatement(batchExecuteParams).promise();
+}
+
+/**
+ * Sometimes these fields are negative because they are based on a regression.
+ */
+function getValueOrDefault(field: string): number {
+  return Math.max(parseFloat(field == 'NaN' || field == null ? '0' : field), 0);
+}
+
+/**
+ * Maps a data row to a table row ready to write to the db.
+ * @param row: row with all data needed to build a [WaterSystemsTableRow].
+ */
+function getTableRowFromRow(row: any): SqlParametersList {
+  const value = row.value;
+  const properties = value.properties;
+  return (
+    new ParcelsTableRowBuilder()
+      .address(properties.address)
+      .publicLeadPrediction(getValueOrDefault(properties.y_score_pub))
+      .privateLeadPrediction(getValueOrDefault(properties.y_score_priv))
+      // Keep JSON formatting. Post-GIS helpers depend on this.
+      .geom(JSON.stringify(value.geometry))
+      .build()
+  );
+}
+
+/**
+ * Reads the S3 file and the number of rows successfully written.
+ * @param s3Params: Params that identity the s3 bucket.
+ * @param rdsDataService: RDS service to connect to the db.
+ * @param startIndex: The row with which to begin writes.
+ * @param numberOfRowsToWrite: The number of entries to write to the db.
+ */
+async function parseS3IntoLeadServiceLinesTableRow(
+  s3Params: AWS.S3.GetObjectRequest,
+  rdsDataService: RDSDataService,
+  startIndex = 0,
+  numberOfRowsToWrite = DEFAULT_NUMBER_ROWS_TO_INSERT,
+): Promise<number> {
+  return new Promise(function (resolve, reject) {
+    let numberRowsParsed = 0;
+    const promises: Promise<BatchExecuteStatementResponse | null>[] = [];
+    const fileStream = S3.getObject(s3Params).createReadStream();
+
+    let pipeline = chain([
+      fileStream,
+      parser(),
+      pick({ filter: 'features' }),
+      streamArray(),
+      new Batch({ batchSize: BATCH_SIZE }),
+    ]);
+
+    const endIndex = startIndex + numberOfRowsToWrite;
+    try {
+      pipeline
+        .on('data', async (rows: any[]) => {
+          // Stop reading stream if this would exceed number of rows to write.
+          if (numberRowsParsed + rows.length > endIndex) {
+            pipeline.destroy();
+          }
+
+          let tableRows: SqlParametersList[] = [];
+          const shouldWriteRows = numberRowsParsed >= startIndex && numberRowsParsed <= endIndex;
+          if (shouldWriteRows) {
+            tableRows = rows.reduce(function (result, row) {
+              if (row.value.properties.address != '' && row.value.properties.address != null) {
+                result.push(getTableRowFromRow(row));
+              }
+              return result;
+            }, []);
+          }
+
+          promises.push(executeBatchOfRows(rdsDataService, tableRows));
+          numberRowsParsed += rows.length;
+        })
+        .on('error', async (error: Error) => {
+          reject(error);
+        })
+        // Gets called by pipeline.destroy()
+        .on('close', async (_: Error) => {
+          await handleEndOfFilestream(promises);
+          resolve(numberRowsParsed);
+        })
+        .on('end', async () => {
+          await handleEndOfFilestream(promises);
+          resolve(numberRowsParsed);
+        });
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+/**
+ * Writes the table rows to the db and adds execution to list of promises.
+ *
+ * @param rdsDataService: RDS service to connect to the db.
+ * @param tableRows: Rows to write to the db.
+ */
+function executeBatchOfRows(
+  rdsDataService: RDSDataService,
+  tableRows: SqlParametersList[],
+): Promise<BatchExecuteStatementResponse | null> {
+  let promise: Promise<BatchExecuteStatementResponse | null> = Promise.resolve(null);
+  if (tableRows.length > 0) {
+    promise = insertBatch(rdsDataService, tableRows);
+    promise.catch((_) => {}); // Suppress unhandled rejection.
+  }
+  return promise;
+}
+
+/**
+ * Logs number and details of errors that occurred for all inserts.
+ * @param promises of SQL executions.
+ */
+async function handleEndOfFilestream(promises: Promise<BatchExecuteStatementResponse | null>[]) {
+  // Unlike Promise.all(), which rejects when a single promise rejects, Promise.allSettled
+  // allows all promises to finish regardless of status and aggregated the results.
+  const result = await Promise.allSettled(promises);
+  const errors = result.filter((p) => p.status == 'rejected') as PromiseRejectedResult[];
+  console.log(`Number errors during insert: ${errors.length}`);
+
+  // Log all the rejected promises to diagnose issues.
+  errors.forEach((error) => console.log(error.reason));
+}
+
+/**
+ * Parses S3 'parcels/toledo_parcel_preds.geojson' file and writes rows
+ * to parcels in the MainCluster postgres db.
+ */
+export async function handler(_: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  const numberRowsToWrite: number = parseInt(
+    process.env.numberRows ?? `${DEFAULT_NUMBER_ROWS_TO_INSERT}`,
+  );
+
+  const s3Params = {
+    Bucket: 'opendataplatformapistaticdata',
+    // The geometries have been simplified. This file also only includes
+    // the rows we currently write to the db to avoid large javascript
+    // objects from being created on streamArray().
+    Key: 'parcels/toledo_parcel_preds.geojson',
+  };
+
+  try {
+    // See https://docs.aws.amazon.com/rds/index.html.
+    const rdsService = new AWS.RDSDataService();
+
+    // Read geojson file and write to parcel table.
+    const numberRows = await parseS3IntoLeadServiceLinesTableRow(
+      s3Params,
+      rdsService,
+      0,
+      numberRowsToWrite,
+    );
+    console.log(`Parsed ${numberRows} rows`);
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ 'Added rows': numberRows }),
+    };
+  } catch (error) {
+    console.log('Error:' + error);
+    throw error;
+  }
+}

--- a/cdk/src/open-data-platform/data-plane/data-import/write-parcels-data.handler.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/write-parcels-data.handler.ts
@@ -17,7 +17,8 @@ const Batch = require('stream-json/utils/Batch');
 
 // Number of rows to write at once.
 const BATCH_SIZE = 10;
-const DEFAULT_NUMBER_ROWS_TO_INSERT = 10000;
+// This file contains < 145k rows
+const DEFAULT_NUMBER_ROWS_TO_INSERT = 50000;
 const SCHEMA = 'schema';
 
 const S3 = new AWS.S3();
@@ -78,7 +79,7 @@ function getTableRowFromRow(row: any): SqlParametersList {
  * Reads the S3 file and the number of rows successfully written.
  * @param s3Params: Params that identity the s3 bucket.
  * @param rdsDataService: RDS service to connect to the db.
- * @param startIndex: The row with which to begin writes.
+ * @param startIndex: The row with which to begin writes (inclusive).
  * @param numberOfRowsToWrite: The number of entries to write to the db.
  */
 async function writeS3FileToTable(
@@ -171,7 +172,7 @@ async function handleEndOfFilestream(promises: Promise<BatchExecuteStatementResp
   console.log(`Number errors during insert: ${errors.length}`);
 
   // Log all the rejected promises to diagnose issues.
-  errors.forEach((error) => console.log(error.reason));
+  errors.forEach((error) => console.log(`Insert error: ${error.reason}`));
 }
 
 /**

--- a/cdk/src/open-data-platform/data-plane/data-import/write-parcels-data.handler.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/write-parcels-data.handler.ts
@@ -81,7 +81,7 @@ function getTableRowFromRow(row: any): SqlParametersList {
  * @param startIndex: The row with which to begin writes.
  * @param numberOfRowsToWrite: The number of entries to write to the db.
  */
-async function parseS3IntoLeadServiceLinesTableRow(
+async function writeS3FileToTable(
   s3Params: AWS.S3.GetObjectRequest,
   rdsDataService: RDSDataService,
   startIndex = 0,
@@ -196,12 +196,7 @@ export async function handler(_: APIGatewayProxyEvent): Promise<APIGatewayProxyR
     const rdsService = new AWS.RDSDataService();
 
     // Read geojson file and write to parcel table.
-    const numberRows = await parseS3IntoLeadServiceLinesTableRow(
-      s3Params,
-      rdsService,
-      0,
-      numberRowsToWrite,
-    );
+    const numberRows = await writeS3FileToTable(s3Params, rdsService, 0, numberRowsToWrite);
     console.log(`Parsed ${numberRows} rows`);
 
     return {

--- a/cdk/src/open-data-platform/data-plane/model/parcel_table.ts
+++ b/cdk/src/open-data-platform/data-plane/model/parcel_table.ts
@@ -1,0 +1,81 @@
+import { SqlParametersList } from 'aws-sdk/clients/rdsdataservice';
+
+/**
+ * Single row for parcels table.
+ */
+class ParcelsTableRow {
+  // Field formatting conforms to rows in the db. Requires less transformations.
+
+  // Parcel name.
+  address: string;
+  // Reported or estimated likelihood of lead pipes for public lines in the boundary.
+  public_lead_prediction: number;
+  // Reported or estimated likelihood of lead pipes for private lines in the boundary.
+  private_lead_prediction: number;
+  // GeoJSON representation of the boundaries.
+  geom: string;
+
+  constructor(
+    address: string,
+    publicLeadPrediction: number,
+    privateLeadPrediction: number,
+    geom: string,
+  ) {
+    this.address = address;
+    this.public_lead_prediction = publicLeadPrediction;
+    this.private_lead_prediction = privateLeadPrediction;
+    this.geom = geom;
+  }
+}
+
+/**
+ * Builder utility for rows of the parcels table.
+ */
+export class ParcelsTableRowBuilder {
+  private readonly _row: ParcelsTableRow;
+
+  constructor() {
+    this._row = new ParcelsTableRow('', '', 0, 0, 0, '', '');
+  }
+
+  address(address: string): ParcelsTableRowBuilder {
+    this._row.address = address;
+    return this;
+  }
+
+  publicLeadPrediction(publicLeadPrediction: number): ParcelsTableRowBuilder {
+    this._row.public_lead_prediction = publicLeadPrediction;
+    return this;
+  }
+
+  privateLeadPrediction(populationServed: number): ParcelsTableRowBuilder {
+    this._row.private_lead_prediction = populationServed;
+    return this;
+  }
+
+  geom(geom: string): ParcelsTableRowBuilder {
+    this._row.geom = geom;
+    return this;
+  }
+
+  build(): SqlParametersList {
+    return [
+      {
+        name: 'address',
+        value: { stringValue: this._row.address },
+      },
+      {
+        name: 'public_lead_prediction',
+        value: { doubleValue: this._row.public_lead_prediction },
+      },
+      {
+        name: 'private_lead_prediction',
+        value: { doubleValue: this._row.private_lead_prediction },
+      },
+      {
+        name: 'geom',
+        value: { stringValue: this._row.geom.toString() },
+      },
+    ];
+  }
+}


### PR DESCRIPTION
## Description

Addresses: [Display parcel level LSL prediction data on the map](https://app.shortcut.com/blueconduit/story/5150/display-parcel-level-lsl-prediction-data-on-the-map)

Adds parcel data (and lead prediction data) to parcels table for city of Toledo. This writes all 140,000 rows in 1 run

### New

Parcels lambda handler that takes parcels/toledo_parcel_preds.geojson and creates rows for db 

### Changed

Schema.sql to remove some columns / rename others for consistency. 

## Testing and Reviewing

Test events in Amazon AWS console 
