### PR TITLE
Fix issues with epa_violations table.

### DIFF
--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -71,8 +71,8 @@ CREATE TABLE IF NOT EXISTS epa_violations(
     violation_code varchar(255) NOT NULL,
     compliance_status varchar(255) NOT NULL,
     start_date DATE NOT NULL,
-    end_date DATE NOT NULL,
-    pws_id varchar(255) NOT NULL REFERENCES water_systems(pws_id),
+    end_date DATE,
+    pws_id varchar(255) NOT NULL,
     PRIMARY KEY(violation_id)
     );
 


### PR DESCRIPTION
Fix SQL issues with epa_violations. This includes:

- Remove FK on water systems, at least until all water systems are included in that table.
- Remove nonnull constraint on end_date since this can be null for ongoing violations.