### PR TITLE
Add state and county columns to demographics

### DIFF
--- a/cdk/src/open-data-platform/data-plane/data-import/write-demographic-data.handler.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/write-demographic-data.handler.ts
@@ -70,6 +70,8 @@ function getTableRowFromRow(row: any): SqlParametersList {
   return (
     new DemographicsTableRowBuilder()
       .censusGeoId(geoId)
+      // Indexes based on:
+      // https://www.census.gov/programs-surveys/geography/guidance/geo-identifiers.html
       .stateGeoId(geoId.substring(0, 2))
       .countyGeoId(geoId.substring(2, 6))
       .name(properties.NAME)

--- a/cdk/src/open-data-platform/data-plane/data-import/write-demographic-data.handler.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/write-demographic-data.handler.ts
@@ -29,8 +29,8 @@ async function insertBatch(
     schema: SCHEMA,
     secretArn: process.env.CREDENTIALS_SECRET ?? '',
     sql: `INSERT INTO demographics (census_geo_id,
-                                    census_state_geo_id,
-                                    census_county_geo_id,
+                                    state_census_geo_id,
+                                    county_census_geo_id,
                                     census_block_name,
                                     total_population,
                                     under_five_population, 
@@ -38,9 +38,9 @@ async function insertBatch(
                                     black_population,
                                     white_population, geom)
           VALUES (:census_geo_id,
-                  :census_state_geo_id,
+                  :state_census_geo_id,
                   :census_county_geo_id,
-                  :census_block_name,
+                  :county_census_geo_id,
                   :total_population,
                   :under_five_population,
                   :poverty_population,
@@ -72,8 +72,8 @@ function getTableRowFromRow(row: any): SqlParametersList {
       .censusGeoId(geoId)
       // Indexes based on:
       // https://www.census.gov/programs-surveys/geography/guidance/geo-identifiers.html
-      .stateGeoId(geoId.substring(0, 2))
-      .countyGeoId(geoId.substring(2, 5))
+      .stateCensusGeoId(geoId.substring(0, 2))
+      .countyCensusGeoId(geoId.substring(0, 5))
       .name(properties.NAME)
       .underFivePopulation(getValueOrDefault(properties.age_under5))
       .povertyPopulation(getValueOrDefault(properties.PovertyTot))

--- a/cdk/src/open-data-platform/data-plane/data-import/write-demographic-data.handler.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/write-demographic-data.handler.ts
@@ -73,7 +73,7 @@ function getTableRowFromRow(row: any): SqlParametersList {
       // Indexes based on:
       // https://www.census.gov/programs-surveys/geography/guidance/geo-identifiers.html
       .stateGeoId(geoId.substring(0, 2))
-      .countyGeoId(geoId.substring(2, 6))
+      .countyGeoId(geoId.substring(2, 5))
       .name(properties.NAME)
       .underFivePopulation(getValueOrDefault(properties.age_under5))
       .povertyPopulation(getValueOrDefault(properties.PovertyTot))

--- a/cdk/src/open-data-platform/data-plane/data-import/write-demographic-data.handler.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/write-demographic-data.handler.ts
@@ -28,12 +28,18 @@ async function insertBatch(
     resourceArn: process.env.RESOURCE_ARN ?? '',
     schema: SCHEMA,
     secretArn: process.env.CREDENTIALS_SECRET ?? '',
-    sql: `INSERT INTO demographics (census_geo_id, census_block_name,
+    sql: `INSERT INTO demographics (census_geo_id,
+                                    census_state_geo_id,
+                                    census_county_geo_id,
+                                    census_block_name,
                                     total_population,
-                                    under_five_population, poverty_population,
+                                    under_five_population, 
+                                    poverty_population,
                                     black_population,
                                     white_population, geom)
           VALUES (:census_geo_id,
+                  :census_state_geo_id,
+                  :census_county_geo_id,
                   :census_block_name,
                   :total_population,
                   :under_five_population,
@@ -59,10 +65,13 @@ function getValueOrDefault(field: string): number {
 function getTableRowFromRow(row: any): SqlParametersList {
   const value = row.value;
   const properties = value.properties;
+  const geoId = properties.GEOID.toString();
 
   return (
     new DemographicsTableRowBuilder()
-      .censusGeoId(properties.GEOID.toString())
+      .censusGeoId(geoId)
+      .stateGeoId(geoId.substring(0, 2))
+      .countyGeoId(geoId.substring(2, 6))
       .name(properties.NAME)
       .underFivePopulation(getValueOrDefault(properties.age_under5))
       .povertyPopulation(getValueOrDefault(properties.PovertyTot))

--- a/cdk/src/open-data-platform/data-plane/model/demographic-table.ts
+++ b/cdk/src/open-data-platform/data-plane/model/demographic-table.ts
@@ -12,8 +12,8 @@ class DemographicsTableRow {
   poverty_population: number;
   black_population: number;
   white_population: number;
-  census_state_geo_id: string;
-  census_county_geo_id: string;
+  state_census_geo_id: string;
+  county_census_geo_id: string;
   geom: string;
 
   constructor(
@@ -24,8 +24,8 @@ class DemographicsTableRow {
     poverty_population: number,
     blackPopulation: number,
     whitePopulation: number,
-    censusStateGeoId: string,
-    censusCountyGeoId: string,
+    stateCensusGeoId: string,
+    countyCensusGeoId: string,
     geom: string,
   ) {
     this.census_geo_id = censusGeoId;
@@ -35,8 +35,8 @@ class DemographicsTableRow {
     this.poverty_population = poverty_population;
     this.black_population = blackPopulation;
     this.white_population = whitePopulation;
-    this.census_state_geo_id = censusStateGeoId;
-    this.census_county_geo_id = censusCountyGeoId;
+    this.state_census_geo_id = stateCensusGeoId;
+    this.county_census_geo_id = countyCensusGeoId;
     this.geom = geom;
   }
 }
@@ -56,13 +56,13 @@ export class DemographicsTableRowBuilder {
     return this;
   }
 
-  stateGeoId(stateGeoId: string): DemographicsTableRowBuilder {
-    this._row.census_state_geo_id = stateGeoId;
+  stateCensusGeoId(stateGeoId: string): DemographicsTableRowBuilder {
+    this._row.state_census_geo_id = stateGeoId;
     return this;
   }
 
-  countyGeoId(countyGeoId: string): DemographicsTableRowBuilder {
-    this._row.census_county_geo_id = countyGeoId;
+  countyCensusGeoId(countyGeoId: string): DemographicsTableRowBuilder {
+    this._row.county_census_geo_id = countyGeoId;
     return this;
   }
 
@@ -132,12 +132,12 @@ export class DemographicsTableRowBuilder {
         value: { doubleValue: this._row.white_population },
       },
       {
-        name: 'census_county_geo_id',
-        value: { stringValue: this._row.census_county_geo_id },
+        name: 'county_census_geo_id',
+        value: { stringValue: this._row.county_census_geo_id },
       },
       {
-        name: 'census_state_geo_id',
-        value: { stringValue: this._row.census_state_geo_id },
+        name: 'state_census_geo_id',
+        value: { stringValue: this._row.state_census_geo_id },
       },
       {
         name: 'geom',

--- a/cdk/src/open-data-platform/data-plane/model/demographic-table.ts
+++ b/cdk/src/open-data-platform/data-plane/model/demographic-table.ts
@@ -12,6 +12,8 @@ class DemographicsTableRow {
   poverty_population: number;
   black_population: number;
   white_population: number;
+  census_state_geo_id: string;
+  census_county_geo_id: string;
   geom: string;
 
   constructor(
@@ -22,6 +24,8 @@ class DemographicsTableRow {
     poverty_population: number,
     blackPopulation: number,
     whitePopulation: number,
+    censusStateGeoId: string,
+    censusCountyGeoId: string,
     geom: string,
   ) {
     this.census_geo_id = censusGeoId;
@@ -31,6 +35,8 @@ class DemographicsTableRow {
     this.poverty_population = poverty_population;
     this.black_population = blackPopulation;
     this.white_population = whitePopulation;
+    this.census_state_geo_id = censusStateGeoId;
+    this.census_county_geo_id = censusCountyGeoId;
     this.geom = geom;
   }
 }
@@ -42,11 +48,21 @@ export class DemographicsTableRowBuilder {
   private readonly _row: DemographicsTableRow;
 
   constructor() {
-    this._row = new DemographicsTableRow('', '', 0, 0, 0, 0, 0, '');
+    this._row = new DemographicsTableRow('', '', 0, 0, 0, 0, 0, '', '', '');
   }
 
   censusGeoId(censusGeoId: string): DemographicsTableRowBuilder {
     this._row.census_geo_id = censusGeoId;
+    return this;
+  }
+
+  stateGeoId(stateGeoId: string): DemographicsTableRowBuilder {
+    this._row.census_state_geo_id = stateGeoId;
+    return this;
+  }
+
+  countyGeoId(countyGeoId: string): DemographicsTableRowBuilder {
+    this._row.census_county_geo_id = countyGeoId;
     return this;
   }
 
@@ -114,6 +130,14 @@ export class DemographicsTableRowBuilder {
       {
         name: 'white_population',
         value: { doubleValue: this._row.white_population },
+      },
+      {
+        name: 'census_county_geo_id',
+        value: { stringValue: this._row.census_county_geo_id },
+      },
+      {
+        name: 'census_state_geo_id',
+        value: { stringValue: this._row.census_state_geo_id },
       },
       {
         name: 'geom',

--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -37,9 +37,9 @@ CREATE TABLE IF NOT EXISTS demographics(
    under_five_population real,
    poverty_population real,
    black_population real,
+   white_population real,
    census_state_geo_id varchar(255) NOT NULL references states(census_geo_id),
    census_county_geo_id varchar(255) NOT NULL references counties(census_geo_id),
-   white_population real,
    geom GEOMETRY(Geometry, 4326),
    PRIMARY KEY(census_geo_id)
 );

--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -38,13 +38,13 @@ CREATE TABLE IF NOT EXISTS demographics(
    poverty_population real,
    black_population real,
    white_population real,
-   census_state_geo_id varchar(255) NOT NULL references states(census_geo_id),
-   census_county_geo_id varchar(255) NOT NULL references counties(census_geo_id),
+   state_census_geo_id varchar(255) NOT NULL references states(census_geo_id),
+   county_census_geo_id varchar(255) NOT NULL references counties(census_geo_id),
    geom GEOMETRY(Geometry, 4326),
    PRIMARY KEY(census_geo_id)
 );
-CREATE INDEX IF NOT EXISTS census_state_geo_id_index ON demographics (census_state_geo_id);
-CREATE INDEX IF NOT EXISTS census_county_geo_id_index ON demographics (census_county_geo_id);
+CREATE INDEX IF NOT EXISTS census_state_geo_id_index ON demographics (state_census_geo_id);
+CREATE INDEX IF NOT EXISTS census_county_geo_id_index ON demographics (county_census_geo_id);
 
 CREATE INDEX IF NOT EXISTS geom_index
     ON demographics

--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -37,6 +37,8 @@ CREATE TABLE IF NOT EXISTS demographics(
     under_five_population real,
     poverty_population real,
     black_population real,
+    census_state_geo_id varchar(255) NOT NULL,
+    census_county_geo_id varchar(255) NOT NULL,
     white_population real,
     geom GEOMETRY(Geometry, 4326),
     PRIMARY KEY(census_geo_id)

--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -43,8 +43,8 @@ CREATE TABLE IF NOT EXISTS demographics(
    geom GEOMETRY(Geometry, 4326),
    PRIMARY KEY(census_geo_id)
 );
-CREATE UNIQUE INDEX IF NOT EXISTS census_state_geo_id_index ON demographics (census_state_geo_id);
-
+CREATE INDEX IF NOT EXISTS census_state_geo_id_index ON demographics (census_state_geo_id);
+CREATE INDEX IF NOT EXISTS census_county_geo_id_index ON demographics (census_county_geo_id);
 
 CREATE INDEX IF NOT EXISTS geom_index
     ON demographics

--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -31,18 +31,20 @@ $$ LANGUAGE plpgsql;
 -- Census-block-level data. TODO: consider renaming the table.
 
 CREATE TABLE IF NOT EXISTS demographics(
-    census_geo_id varchar(255) NOT NULL,
-    census_block_name varchar(255),
-    total_population real,
-    under_five_population real,
-    poverty_population real,
-    black_population real,
-    census_state_geo_id varchar(255) NOT NULL,
-    census_county_geo_id varchar(255) NOT NULL,
-    white_population real,
-    geom GEOMETRY(Geometry, 4326),
-    PRIMARY KEY(census_geo_id)
+   census_geo_id varchar(255) NOT NULL,
+   census_block_name varchar(255),
+   total_population real,
+   under_five_population real,
+   poverty_population real,
+   black_population real,
+   census_state_geo_id varchar(255) NOT NULL references states(census_geo_id),
+   census_county_geo_id varchar(255) NOT NULL references counties(census_geo_id),
+   white_population real,
+   geom GEOMETRY(Geometry, 4326),
+   PRIMARY KEY(census_geo_id)
 );
+CREATE UNIQUE INDEX IF NOT EXISTS census_state_geo_id_index ON demographics (census_state_geo_id);
+
 
 CREATE INDEX IF NOT EXISTS geom_index
     ON demographics


### PR DESCRIPTION
## Description

Addresses: [Complete data transformation](https://app.shortcut.com/blueconduit/story/5678/complete-data-transformation)

Add state and county geo id to the demographics table. We need this in order to do joins with state and county tables. Geometric spatial joins are too slow for our purposes. 

The table needs to be dropped and reloaded to make all the aggregations work. Aggregations will require these foreign keys be populated.

### New

State and county geo ids added to demographics table. 

## Testing and Reviewing

Reloaded entire demographics table with new columns 
