### PR TITLE
Hardcode VPC id to force correct lookup.

### DIFF
--- a/cdk/cdk.context.json
+++ b/cdk/cdk.context.json
@@ -46,5 +46,48 @@
         ]
       }
     ]
+  },
+  "vpc-provider:account=036999211278:filter.vpc-id=vpc-03af3621549e79f22:region=us-east-2:returnAsymmetricSubnets=true": {
+    "vpcId": "vpc-03af3621549e79f22",
+    "vpcCidrBlock": "10.0.0.0/16",
+    "availabilityZones": [],
+    "subnetGroups": [
+      {
+        "name": "private",
+        "type": "Private",
+        "subnets": [
+          {
+            "subnetId": "subnet-077d77e1608090787",
+            "cidr": "10.0.16.0/20",
+            "availabilityZone": "us-east-2a",
+            "routeTableId": "rtb-065349a59f9f4dd4b"
+          },
+          {
+            "subnetId": "subnet-081dcabd017e43f1f",
+            "cidr": "10.0.32.0/20",
+            "availabilityZone": "us-east-2b",
+            "routeTableId": "rtb-0bd3ca3dc8683b8c6"
+          }
+        ]
+      },
+      {
+        "name": "public",
+        "type": "Public",
+        "subnets": [
+          {
+            "subnetId": "subnet-016ca4f97c9aa67ba",
+            "cidr": "10.0.0.0/24",
+            "availabilityZone": "us-east-2a",
+            "routeTableId": "rtb-0c2fa1e949c549af5"
+          },
+          {
+            "subnetId": "subnet-0da62c3943a440750",
+            "cidr": "10.0.1.0/24",
+            "availabilityZone": "us-east-2b",
+            "routeTableId": "rtb-06223de8e27666d5b"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/cdk/src/open-data-platform/network/network-stack.ts
+++ b/cdk/src/open-data-platform/network/network-stack.ts
@@ -28,7 +28,7 @@ export class NetworkStack extends Stack {
           // Temporarily hardcode the ID since the tag lookup was not finding the right VPC.
           // TODO: replace with search by tag.
           vpcId: 'vpc-03af3621549e79f22',
-          region: 'us-east2', // The lookup was
+          region: 'us-east-2',
         })
       : // Else, create a new VPC.
         // Note that changes here will not be reflected on deployment if a VPC already exists.

--- a/cdk/src/open-data-platform/network/network-stack.ts
+++ b/cdk/src/open-data-platform/network/network-stack.ts
@@ -21,9 +21,14 @@ export class NetworkStack extends Stack {
         // By default, an AWS account can only have 5 Elastic IP addresses. Reusing existing VPCs keeps
         // that number down.
         ec2.Vpc.fromLookup(this, id, {
-          tags: {
-            Project: projectName,
-          },
+          // tags: {
+          //   Project: projectName,
+          // },
+
+          // Temporarily hardcode the ID since the tag lookup was not finding the right VPC.
+          // TODO: replace with search by tag.
+          vpcId: 'vpc-03af3621549e79f22',
+          region: 'us-east2', // The lookup was
         })
       : // Else, create a new VPC.
         // Note that changes here will not be reflected on deployment if a VPC already exists.

--- a/cdk/src/pipeline/pipeline-stack.ts
+++ b/cdk/src/pipeline/pipeline-stack.ts
@@ -42,23 +42,23 @@ export class PipelineStack extends Stack {
       synthCodeBuildDefaults: {
         buildEnvironment: {
           // TODO: update to a build image which supports node 16 on next CDK release
-          buildImage: LinuxBuildImage.STANDARD_5_0
+          buildImage: LinuxBuildImage.STANDARD_5_0,
         },
         partialBuildSpec: BuildSpec.fromObject({
           phases: {
             install: {
-              "runtime-versions": {
+              'runtime-versions': {
                 // TODO: update to node 16 once new codebuild images are available in next CDK release
-                nodejs: 14
-              }
-            }
-          }
-        })
-      }
+                nodejs: 14,
+              },
+            },
+          },
+        }),
+      },
     });
 
     pipeline.addStage(
-      new OpenDataPlatformStage(scope, 'Dev', {
+      new OpenDataPlatformStage(this, 'Dev', {
         env: { account: '036999211278', region: 'us-east-2' },
         tags: { Project: util.projectName, Environment: util.EnvType.Development },
         envType: util.EnvType.Development,

--- a/cdk/src/util.ts
+++ b/cdk/src/util.ts
@@ -25,9 +25,6 @@ export interface CommonProps extends StackProps {
 
 export const stackName = (id: StackId, e: EnvType): string => {
   const base = `${projectName}${StackId[id]}`;
-  // Network stuff should be shared across all instances within a given AWS account, so use a
-  // common name for the network stack.
-  if (id === StackId.Network) return base;
   if (e == EnvType.Sandbox && process.env.USER) return `${process.env.USER}-${base}`;
   return base;
 };


### PR DESCRIPTION
## Description

The lookup by tag was returning some other VPC that I couldn't actually find in our AWS account. So this hardcodes the real VPC so it's unambiguous.