### PR TITLE
Add parcel lead connections

### DIFF
--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -347,6 +347,7 @@ BEGIN
                         w.pws_id                               AS pws_id,
                         w.pws_name                             AS pws_name,
                         SUM(w.lead_connections_count)          AS lead_connections_count,
+                        SUM(w.service_connections_count)       AS service_connections_count,
                         SUM(w.population_served)               AS population_served
                  FROM water_systems w
                  WHERE ST_Transform(w.geom, 3857) && ST_TileEnvelope(z, x, y)

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script lang='ts'>
-import { defineComponent, onMounted, provide, reactive } from 'vue';
+import { defineComponent, provide, reactive } from 'vue';
 import '@blueconduit/copper/dist/css/copper.css';
 import NavigationBar from './components/NavigationBar.vue';
 import { State } from './model/state';

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -8,16 +8,18 @@ import '@blueconduit/copper/dist/css/copper.css';
 import NavigationBar from './components/NavigationBar.vue';
 import { State } from './model/state';
 
-import { leadAndCopperViolationsByCountyDataLayer } from './data_layer_configs/lead_and_copper_violations_by_water_system_config';
 import { leadServiceLinesByWaterSystemLayer } from './data_layer_configs/lead_service_lines_by_water_systems_config';
-import { populationDataByCensusBlockLayer } from './data_layer_configs/population_by_census_block_config';
 import { stateKey } from './injection_keys';
 import { DataLayer, MapLayer } from './model/data_layer';
+import { leadServiceLinesByParcelLayer } from './data_layer_configs/lead_service_lines_by_parcel_config';
+import { populationDataByCensusBlockLayer } from './data_layer_configs/population_by_census_block_config';
+import { leadAndCopperViolationsByCountyDataLayer } from './data_layer_configs/lead_and_copper_violations_by_water_system_config';
 
 const DATA_LAYERS = new Map<MapLayer, DataLayer>([
   [MapLayer.LeadServiceLineByWaterSystem, leadServiceLinesByWaterSystemLayer],
   [MapLayer.LeadAndCopperRuleViolationsByWaterSystem, leadAndCopperViolationsByCountyDataLayer],
   [MapLayer.PopulationByCensusBlock, populationDataByCensusBlockLayer],
+  [MapLayer.LeadServiceLineByParcel, leadServiceLinesByParcelLayer],
 ]);
 
 // Base URL for REST API in Amazon API Gateway.

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -11,9 +11,9 @@ import { State } from './model/state';
 import { leadServiceLinesByWaterSystemLayer } from './data_layer_configs/lead_service_lines_by_water_systems_config';
 import { stateKey } from './injection_keys';
 import { DataLayer, MapLayer } from './model/data_layer';
-import { leadServiceLinesByParcelLayer } from './data_layer_configs/lead_service_lines_by_parcel_config';
 import { populationDataByCensusBlockLayer } from './data_layer_configs/population_by_census_block_config';
 import { leadAndCopperViolationsByCountyDataLayer } from './data_layer_configs/lead_and_copper_violations_by_water_system_config';
+import { leadServiceLinesByParcelLayer } from './data_layer_configs/lead_service_lines_by_parcel_config';
 
 const DATA_LAYERS = new Map<MapLayer, DataLayer>([
   [MapLayer.LeadServiceLineByWaterSystem, leadServiceLinesByWaterSystemLayer],

--- a/client/src/components/MapPopupContent.vue
+++ b/client/src/components/MapPopupContent.vue
@@ -67,6 +67,10 @@ export default defineComponent({
         const featurePropertyKey = entry.name;
         const label = entry.label;
         let propertyValue = this.properties.get(featurePropertyKey);
+        // Skip over optional properties which have no value.
+        if (entry.optional && propertyValue == null) {
+          continue;
+        }
         switch (entry.dataType) {
           case FeaturePropertyDataType.String: {
             propertyValue = propertyValue ?? '';
@@ -77,7 +81,8 @@ export default defineComponent({
             break;
           }
           case FeaturePropertyDataType.Percentage: {
-            propertyValue = `${parseFloat(propertyValue ?? '0').toLocaleString()}%`;
+            const percentageValue = parseFloat(propertyValue ?? '0') * 100;
+            propertyValue = `${percentageValue.toLocaleString()}%`;
             break;
           }
           default: {

--- a/client/src/components/MapView.vue
+++ b/client/src/components/MapView.vue
@@ -74,10 +74,12 @@ export default defineComponent({
 
       this.map.setLayoutProperty(styleLayerId, 'visibility', visible ? 'visible' : 'none');
 
-      // Update the router params when toggling layers to visible. Do not update for leadServiceLinesByParcelLayer, which is not a visible layer.
-      if (visible &&
+      // Update the router params when toggling layers to visible. Do not update
+      // for leadServiceLinesByParcelLayer, which is not a visible layer.
+      const shouldUpdateRouterParam = visible &&
         router.currentRoute.value.query.layer != styleLayerId &&
-        styleLayerId != leadServiceLinesByParcelLayer.styleLayer.id) {
+        styleLayerId != leadServiceLinesByParcelLayer.styleLayer.id;
+      if (shouldUpdateRouterParam) {
         router.push({ query: Object.assign({}, router.currentRoute.value.query, { layer: styleLayerId }) });
       }
     },
@@ -195,9 +197,7 @@ export default defineComponent({
      * source for the Lead Connections layer.
      */
     setUpZoomListener(): void {
-      if (this.map == null) return;
-
-      this.map.on('zoom', () => {
+      this.map?.on('zoom', () => {
         if (this.map == null) return;
 
         // If zoomed past parcel zoom level, switch to parcel-level data source.

--- a/client/src/components/MapView.vue
+++ b/client/src/components/MapView.vue
@@ -146,6 +146,8 @@ export default defineComponent({
               const clickedFeatureProperties: { [name: string]: any; } = e.features[0].properties as {};
               const popupInfo = this.state?.currentDataLayer?.popupInfo;
 
+              console.log(clickedFeatureProperties);
+              
               this.createMapPopup(e.lngLat, /* popupData= */
                 {
                   title: popupInfo?.title ?? '',

--- a/client/src/components/MapView.vue
+++ b/client/src/components/MapView.vue
@@ -195,10 +195,12 @@ export default defineComponent({
 
       this.map.on('zoom', () => {
         if (this.map == null) return;
-        if (this.map.getZoom() > 10 && this.state.currentDataLayer?.id == MapLayer.LeadServiceLineByWaterSystem) {
-          this.toggleLayerVisibility(leadServiceLinesByParcelLayer, leadServiceLinesByWaterSystemLayer);
-        } else if (this.map.getZoom() > 10 && this.state.currentDataLayer?.id == MapLayer.LeadServiceLineByParcel) {
-          this.toggleLayerVisibility(leadServiceLinesByWaterSystemLayer, leadServiceLinesByParcelLayer);
+        if (this.map.getZoom() >= 12
+          && this.state?.currentDataLayer?.id == MapLayer.LeadServiceLineByWaterSystem) {
+          this.state?.setCurrentDataLayer(leadServiceLinesByParcelLayer);
+        } else if (this.map.getZoom() < 12
+          && this.state?.currentDataLayer?.id == MapLayer.LeadServiceLineByParcel) {
+          this.state?.setCurrentDataLayer(leadServiceLinesByWaterSystemLayer);
         }
       });
     },

--- a/client/src/components/SearchBar.vue
+++ b/client/src/components/SearchBar.vue
@@ -27,7 +27,7 @@ import VueSelect from 'vue-select';
 import 'vue-select/dist/vue-select.css';
 import { State } from '../model/state';
 import { stateKey } from '../injection_keys';
-import { DataLayer } from '../model/data_layer';
+import { DataLayer, MapLayer } from '../model/data_layer';
 import MapGeocoderWrapper from './MapGeocoderWrapper.vue';
 
 export default defineComponent({
@@ -75,7 +75,9 @@ export default defineComponent({
       handler(newState: State): void {
         if (newState != null) {
           this.options = newState.dataLayers.filter(layer => layer.visibleInSearchBar);
-          this.selectedOption = newState.currentDataLayer;
+          if (newState.currentDataLayer?.id != MapLayer.LeadServiceLineByParcel) {
+            this.selectedOption = newState.currentDataLayer;
+          }
         }
       },
       // Make watcher deep, meaning that this will be triggered on a change to any nested field of state.

--- a/client/src/components/SearchBar.vue
+++ b/client/src/components/SearchBar.vue
@@ -20,7 +20,7 @@
   </div>
 </template>
 
-<script lang="ts">
+<script lang='ts'>
 import { defineComponent, inject } from 'vue';
 import SearchBarOption from './SearchBarOption.vue';
 import VueSelect from 'vue-select';

--- a/client/src/components/SearchBar.vue
+++ b/client/src/components/SearchBar.vue
@@ -74,7 +74,7 @@ export default defineComponent({
     state: {
       handler(newState: State): void {
         if (newState != null) {
-          this.options = newState.dataLayers;
+          this.options = newState.dataLayers.filter(layer => layer.visibleInSearchBar);
           this.selectedOption = newState.currentDataLayer;
         }
       },

--- a/client/src/data_layer_configs/lead_and_copper_violations_by_water_system_config.ts
+++ b/client/src/data_layer_configs/lead_and_copper_violations_by_water_system_config.ts
@@ -1,11 +1,4 @@
-import {
-  DataSourceType,
-  FeaturePropertyDataType,
-  LegendInfo,
-  MapLayer,
-  PopupInfo,
-  TileDataLayer,
-} from '@/model/data_layer';
+import { DataSourceType, FeaturePropertyDataType, LegendInfo, MapLayer, PopupInfo, TileDataLayer } from '@/model/data_layer';
 import { Expression, FillLayer } from 'mapbox-gl';
 import { getLegendBucketsAsList, tileServerHost } from '@/util/data_layer_util';
 
@@ -94,4 +87,5 @@ export const leadAndCopperViolationsByCountyDataLayer: TileDataLayer = {
   legendInfo: legendInfo,
   popupInfo: popupInfo,
   styleLayer: styleLayer,
+  visibleInSearchBar: true,
 };

--- a/client/src/data_layer_configs/lead_and_copper_violations_by_water_system_config.ts
+++ b/client/src/data_layer_configs/lead_and_copper_violations_by_water_system_config.ts
@@ -1,4 +1,11 @@
-import { DataSourceType, FeaturePropertyDataType, LegendInfo, MapLayer, PopupInfo, TileDataLayer } from '@/model/data_layer';
+import {
+  DataSourceType,
+  FeaturePropertyDataType,
+  LegendInfo,
+  MapLayer,
+  PopupInfo,
+  TileDataLayer,
+} from '@/model/data_layer';
 import { Expression, FillLayer } from 'mapbox-gl';
 import { getLegendBucketsAsList, tileServerHost } from '@/util/data_layer_util';
 

--- a/client/src/data_layer_configs/lead_service_lines_by_parcel_config.ts
+++ b/client/src/data_layer_configs/lead_service_lines_by_parcel_config.ts
@@ -2,7 +2,10 @@ import {DataSourceType, FeaturePropertyDataType, LegendInfo, MapLayer, PopupInfo
 import {FillLayer} from 'mapbox-gl';
 import {colorMapToBuckets, tileServerHost} from '@/util/data_layer_util';
 
+// TODO(kailamjeter): move from lead likelihood % -> known / not likely / high likely etc.
+
 const DEFAULT_NULL_COLOR = '#d3d3d3';
+const TABLE_NAME = 'public.parcels';
 
 /**
  * Maps legend buckets to the hex values.
@@ -59,7 +62,7 @@ export const styleLayer: FillLayer = {
   id: `${MapLayer.LeadServiceLineByParcel}-style`,
   source: MapLayer.LeadServiceLineByParcel,
   // Corresponds to the table in the database.
-  'source-layer': 'public.parcels',
+  'source-layer': TABLE_NAME,
   type: 'fill',
   paint: {
     'fill-color': [
@@ -97,7 +100,7 @@ const popupInfo: PopupInfo = {
 export const leadServiceLinesByParcelLayer: TileDataLayer = {
   source: {
     type: DataSourceType.Vector,
-    tiles: [`https://${tileServerHost()}/tiles/v1/public.parcels/{z}/{x}/{y}.pbf`],
+    tiles: [`https://${tileServerHost()}/tiles/v1/${TABLE_NAME}/{z}/{x}/{y}.pbf`],
   },
   id: MapLayer.LeadServiceLineByParcel,
   name: 'Lead Service Line Estimate (Home)',

--- a/client/src/data_layer_configs/lead_service_lines_by_parcel_config.ts
+++ b/client/src/data_layer_configs/lead_service_lines_by_parcel_config.ts
@@ -7,44 +7,37 @@ import {
   TileDataLayer,
 } from '@/model/data_layer';
 import { FillLayer } from 'mapbox-gl';
-import { colorMapToBuckets, tileServerHost } from '@/util/data_layer_util';
+import { getLegendBucketsAsList, tileServerHost } from '@/util/data_layer_util';
 
 // TODO(kailamjeter): move from lead likelihood % -> known / not likely / high likely etc.
 
 const DEFAULT_NULL_COLOR = '#d3d3d3';
 const TABLE_NAME = 'public.parcels';
 
-/**
- * Maps legend buckets to the hex values.
- */
-const LEGEND_COLOR_MAPPING = [
-  0,
-  '#9fcd7c',
-  5,
-  '#f7e5af',
-  38,
-  '#f4a163',
-  99.7,
-  '#ff5934',
-  99.9,
-  '#d73819',
+const LEGEND_VALUES = [
+  {
+    bucketValue: 0,
+    bucketColor: '#9fcd7c',
+  },
+  {
+    bucketValue: 5,
+    bucketColor: '#f7e5af',
+  },
+  {
+    bucketValue: 38,
+    bucketColor: '#f4a163',
+  },
+  {
+    bucketValue: 99.7,
+    bucketColor: '#ff5934',
+  },
+  {
+    bucketValue: 99.9,
+    bucketColor: '#d73819',
+  },
 ];
 
-/**
- * Maps feature property values to colors to be rendered on the map.
- */
-const INTERPOLATION_COLOR_MAPPING = [
-  0,
-  '#9fcd7c',
-  0.05,
-  '#f7e5af',
-  0.38,
-  '#f4a163',
-  0.997,
-  '#ff5934',
-  0.999,
-  '#d73819',
-];
+const percentLeadLikelihood = ['*', 100, ['get', 'public_lead_prediction']];
 
 /**
  * Mapbox expression which interpolates pairs of bucket 'stops' + colors to produce continuous
@@ -56,13 +49,14 @@ const leadConnectionLegendInterpolation = [
   'interpolate',
   ['linear'],
   // Provides ratio of lead service lines : total service lines.
-  ['get', 'public_lead_prediction'],
-  ...INTERPOLATION_COLOR_MAPPING,
+  percentLeadLikelihood,
+  ...getLegendBucketsAsList(LEGEND_VALUES),
 ];
 
 const legendInfo: LegendInfo = {
   title: 'Percentage estimate of service line being lead',
-  bucketMap: colorMapToBuckets(LEGEND_COLOR_MAPPING),
+  buckets: LEGEND_VALUES,
+  bucketLabelType: FeaturePropertyDataType.Percentage,
 };
 
 export const styleLayer: FillLayer = {

--- a/client/src/data_layer_configs/lead_service_lines_by_parcel_config.ts
+++ b/client/src/data_layer_configs/lead_service_lines_by_parcel_config.ts
@@ -7,18 +7,16 @@ const DEFAULT_NULL_COLOR = '#d3d3d3';
 /**
  * Maps legend buckets to the hex values.
  */
-const LEGEND_COLOR_MAPPING = [
+const INTERPOLATION_COLOR_MAPPING = [
   0,
   '#9fcd7c',
-  0.25,
+  0.05,
   '#f7e5af',
-  0.33,
-  '#f9bd64',
-  0.5,
+  0.38,
   '#f4a163',
-  0.6,
+  0.997,
   '#ff5934',
-  0.75,
+  0.999,
   '#d73819',
 ];
 
@@ -32,13 +30,13 @@ const leadConnectionLegendInterpolation = [
   'interpolate',
   ['linear'],
   // Provides ratio of lead service lines : total service lines.
-  ['/', ['get', 'lead_connections_count'], ['get', 'service_connections_count']],
-  ...LEGEND_COLOR_MAPPING,
+  ['get', 'public_lead_prediction'],
+  ...INTERPOLATION_COLOR_MAPPING,
 ];
 
 const legendInfo: LegendInfo = {
-  title: 'Proportion of lead lines to all service lines',
-  bucketMap: colorMapToBuckets(LEGEND_COLOR_MAPPING),
+  title: 'Likelihood of lead (0-1)',
+  bucketMap: colorMapToBuckets(INTERPOLATION_COLOR_MAPPING),
 };
 
 export const styleLayer: FillLayer = {
@@ -48,7 +46,12 @@ export const styleLayer: FillLayer = {
   'source-layer': 'public.parcels',
   type: 'fill',
   paint: {
-    'fill-color': '#f4a163',
+    'fill-color': [
+      'case',
+      ['==', ['get', 'public_lead_prediction'], null],
+      DEFAULT_NULL_COLOR,
+      leadConnectionLegendInterpolation,
+    ],
     'fill-opacity': 0.75,
   },
   layout: {
@@ -58,29 +61,19 @@ export const styleLayer: FillLayer = {
 };
 
 const popupInfo: PopupInfo = {
-  title: 'Water system',
-  subtitle: 'Estimated lead service lines',
-  detailsTitle: 'Water system information',
+  title: 'Home',
+  subtitle: 'Lead likelihood',
+  detailsTitle: 'Likelihood from 0-1 that the public service lines contain lead.',
   featureProperties: [
     {
-      label: 'Number of lead connections',
-      name: 'lead_connections_count',
-      dataType: FeaturePropertyDataType.Number,
-    },
-    {
-      label: 'Number of service lines',
-      name: 'service_connections_count',
-      dataType: FeaturePropertyDataType.Number,
-    },
-    {
-      label: 'Population served by water system',
-      name: 'population_served',
-      dataType: FeaturePropertyDataType.Number,
-    },
-    {
-      label: 'EPA identifier for water system',
-      name: 'pws_id',
+      label: 'Home address',
+      name: 'address',
       dataType: FeaturePropertyDataType.String,
+    },
+    {
+      label: 'Lead likelihood',
+      name: 'public_lead_prediction',
+      dataType: FeaturePropertyDataType.Number,
     },
   ],
 };

--- a/client/src/data_layer_configs/lead_service_lines_by_parcel_config.ts
+++ b/client/src/data_layer_configs/lead_service_lines_by_parcel_config.ts
@@ -1,6 +1,13 @@
-import {DataSourceType, FeaturePropertyDataType, LegendInfo, MapLayer, PopupInfo, TileDataLayer} from '@/model/data_layer';
-import {FillLayer} from 'mapbox-gl';
-import {colorMapToBuckets, tileServerHost} from '@/util/data_layer_util';
+import {
+  DataSourceType,
+  FeaturePropertyDataType,
+  LegendInfo,
+  MapLayer,
+  PopupInfo,
+  TileDataLayer,
+} from '@/model/data_layer';
+import { FillLayer } from 'mapbox-gl';
+import { colorMapToBuckets, tileServerHost } from '@/util/data_layer_util';
 
 // TODO(kailamjeter): move from lead likelihood % -> known / not likely / high likely etc.
 

--- a/client/src/data_layer_configs/lead_service_lines_by_parcel_config.ts
+++ b/client/src/data_layer_configs/lead_service_lines_by_parcel_config.ts
@@ -1,11 +1,27 @@
-import { DataSourceType, FeaturePropertyDataType, LegendInfo, MapLayer, PopupInfo, TileDataLayer } from '@/model/data_layer';
-import { FillLayer } from 'mapbox-gl';
-import { colorMapToBuckets, tileServerHost } from '@/util/data_layer_util';
+import {DataSourceType, FeaturePropertyDataType, LegendInfo, MapLayer, PopupInfo, TileDataLayer} from '@/model/data_layer';
+import {FillLayer} from 'mapbox-gl';
+import {colorMapToBuckets, tileServerHost} from '@/util/data_layer_util';
 
 const DEFAULT_NULL_COLOR = '#d3d3d3';
 
 /**
  * Maps legend buckets to the hex values.
+ */
+const LEGEND_COLOR_MAPPING = [
+  0,
+  '#9fcd7c',
+  5,
+  '#f7e5af',
+  38,
+  '#f4a163',
+  99.7,
+  '#ff5934',
+  99.9,
+  '#d73819',
+];
+
+/**
+ * Maps feature property values to colors to be rendered on the map.
  */
 const INTERPOLATION_COLOR_MAPPING = [
   0,
@@ -35,8 +51,8 @@ const leadConnectionLegendInterpolation = [
 ];
 
 const legendInfo: LegendInfo = {
-  title: 'Likelihood of lead (0-1)',
-  bucketMap: colorMapToBuckets(INTERPOLATION_COLOR_MAPPING),
+  title: 'Percentage estimate of service line being lead',
+  bucketMap: colorMapToBuckets(LEGEND_COLOR_MAPPING),
 };
 
 export const styleLayer: FillLayer = {
@@ -63,17 +79,17 @@ export const styleLayer: FillLayer = {
 const popupInfo: PopupInfo = {
   title: 'Home',
   subtitle: 'Lead likelihood',
-  detailsTitle: 'Likelihood from 0-1 that the public service lines contain lead.',
+  detailsTitle: 'Percentage likelihood that the public service lines contain lead.',
   featureProperties: [
     {
       label: 'Home address',
       name: 'address',
-      dataType: FeaturePropertyDataType.String,
+      dataType: FeaturePropertyDataType.Address,
     },
     {
       label: 'Lead likelihood',
       name: 'public_lead_prediction',
-      dataType: FeaturePropertyDataType.Number,
+      dataType: FeaturePropertyDataType.Percentage,
     },
   ],
 };
@@ -84,7 +100,7 @@ export const leadServiceLinesByParcelLayer: TileDataLayer = {
     tiles: [`https://${tileServerHost()}/tiles/v1/public.parcels/{z}/{x}/{y}.pbf`],
   },
   id: MapLayer.LeadServiceLineByParcel,
-  name: 'Lead Service Lines',
+  name: 'Lead Service Line Estimate (Home)',
   legendInfo: legendInfo,
   popupInfo: popupInfo,
   styleLayer: styleLayer,

--- a/client/src/data_layer_configs/lead_service_lines_by_water_systems_config.ts
+++ b/client/src/data_layer_configs/lead_service_lines_by_water_systems_config.ts
@@ -10,7 +10,7 @@ import { FillLayer } from 'mapbox-gl';
 import { getLegendBucketsAsList, tileServerHost } from '@/util/data_layer_util';
 
 const DEFAULT_NULL_COLOR = '#d3d3d3';
-const TABLE_NAME = 'public.water_systems';
+const TABLE_NAME = 'public.lead_connections_function_source';
 
 const LEGEND_VALUES = [
   {
@@ -72,12 +72,7 @@ export const styleLayer: FillLayer = {
   'source-layer': TABLE_NAME,
   type: 'fill',
   paint: {
-    'fill-color': [
-      'case',
-      ['==', ['get', 'lead_connections_count'], null],
-      DEFAULT_NULL_COLOR,
-      leadConnectionLegendInterpolation,
-    ],
+    'fill-color': '#9fcd7c',
     'fill-opacity': 0.75,
   },
   layout: {
@@ -117,7 +112,7 @@ const popupInfo: PopupInfo = {
 export const leadServiceLinesByWaterSystemLayer: TileDataLayer = {
   source: {
     type: DataSourceType.Vector,
-    tiles: [`https://${tileServerHost()}/tiles/v1/${TABLE_NAME}/{z}/{x}/{y}.pbf`],
+    tiles: [`https://${tileServerHost()}/tiles/v1/rpc/${TABLE_NAME}/{z}/{x}/{y}.pbf`],
     // Helps with latency to reduce fetching unneeded tiles.
     minzoom: 3,
     maxzoom: 16,

--- a/client/src/data_layer_configs/lead_service_lines_by_water_systems_config.ts
+++ b/client/src/data_layer_configs/lead_service_lines_by_water_systems_config.ts
@@ -60,7 +60,7 @@ const leadConnectionLegendInterpolation = [
 ];
 
 const legendInfo: LegendInfo = {
-  title: 'Percent of service lines estimated to be lead',
+  title: 'Percentage of service lines estimated to be lead',
   buckets: LEGEND_VALUES,
   bucketLabelType: FeaturePropertyDataType.Percentage,
 };
@@ -72,7 +72,12 @@ export const styleLayer: FillLayer = {
   'source-layer': TABLE_NAME,
   type: 'fill',
   paint: {
-    'fill-color': '#9fcd7c',
+    'fill-color': [
+      'case',
+      ['==', ['get', 'lead_connections_count'], null],
+      DEFAULT_NULL_COLOR,
+      leadConnectionLegendInterpolation,
+    ],
     'fill-opacity': 0.75,
   },
   layout: {
@@ -87,6 +92,18 @@ const popupInfo: PopupInfo = {
   detailsTitle: 'Water system information',
   featureProperties: [
     {
+      label: 'State name',
+      name: 'state_name',
+      dataType: FeaturePropertyDataType.String,
+      optional: true,
+    },
+    {
+      label: 'EPA identifier for water system',
+      name: 'pws_id',
+      dataType: FeaturePropertyDataType.String,
+      optional: true,
+    },
+    {
       label: 'Number of lead connections',
       name: 'lead_connections_count',
       dataType: FeaturePropertyDataType.Number,
@@ -97,14 +114,9 @@ const popupInfo: PopupInfo = {
       dataType: FeaturePropertyDataType.Number,
     },
     {
-      label: 'Population served by water system',
+      label: 'Population served',
       name: 'population_served',
       dataType: FeaturePropertyDataType.Number,
-    },
-    {
-      label: 'EPA identifier for water system',
-      name: 'pws_id',
-      dataType: FeaturePropertyDataType.String,
     },
   ],
 };

--- a/client/src/data_layer_configs/lead_service_lines_by_water_systems_config.ts
+++ b/client/src/data_layer_configs/lead_service_lines_by_water_systems_config.ts
@@ -123,5 +123,4 @@ export const leadServiceLinesByWaterSystemLayer: TileDataLayer = {
   popupInfo: popupInfo,
   styleLayer: styleLayer,
   visibleInSearchBar: true,
-
 };

--- a/client/src/data_layer_configs/population_by_census_block_config.ts
+++ b/client/src/data_layer_configs/population_by_census_block_config.ts
@@ -1,4 +1,11 @@
-import { DataSourceType, FeaturePropertyDataType, LegendInfo, MapLayer, PopupInfo, TileDataLayer } from '@/model/data_layer';
+import {
+  DataSourceType,
+  FeaturePropertyDataType,
+  LegendInfo,
+  MapLayer,
+  PopupInfo,
+  TileDataLayer,
+} from '@/model/data_layer';
 import { FillLayer } from 'mapbox-gl';
 import { getLegendBucketsAsList, tileServerHost } from '@/util/data_layer_util';
 

--- a/client/src/data_layer_configs/population_by_census_block_config.ts
+++ b/client/src/data_layer_configs/population_by_census_block_config.ts
@@ -165,5 +165,4 @@ export const populationDataByCensusBlockLayer: TileDataLayer = {
   popupInfo: popupInfo,
   styleLayer: styleLayer,
   visibleInSearchBar: true,
-
 };

--- a/client/src/data_layer_configs/population_by_census_block_config.ts
+++ b/client/src/data_layer_configs/population_by_census_block_config.ts
@@ -1,11 +1,4 @@
-import {
-  DataSourceType,
-  FeaturePropertyDataType,
-  LegendInfo,
-  MapLayer,
-  PopupInfo,
-  TileDataLayer,
-} from '@/model/data_layer';
+import { DataSourceType, FeaturePropertyDataType, LegendInfo, MapLayer, PopupInfo, TileDataLayer } from '@/model/data_layer';
 import { FillLayer } from 'mapbox-gl';
 import { getLegendBucketsAsList, tileServerHost } from '@/util/data_layer_util';
 
@@ -171,4 +164,6 @@ export const populationDataByCensusBlockLayer: TileDataLayer = {
   legendInfo: legendInfo,
   popupInfo: popupInfo,
   styleLayer: styleLayer,
+  visibleInSearchBar: true,
+
 };

--- a/client/src/model/data_layer.ts
+++ b/client/src/model/data_layer.ts
@@ -1,4 +1,4 @@
-import { AnyLayer, AnySourceData, FillLayer, VectorSource } from 'mapbox-gl';
+import { AnySourceData, FillLayer, VectorSource } from 'mapbox-gl';
 
 /**
  * A data layer on the map.
@@ -77,8 +77,10 @@ export interface FeatureProperty {
   label: string;
   // Name of this feature property.
   name: string;
-  /// Type of data to configure parsing
+  // Type of data to configure parsing
   dataType: FeaturePropertyDataType;
+  // Whether this property is optional. Optional values may be null or not exist in the list.
+  optional?: boolean;
 }
 
 /**

--- a/client/src/model/data_layer.ts
+++ b/client/src/model/data_layer.ts
@@ -21,6 +21,8 @@ export interface DataLayer {
   popupInfo: PopupInfo;
   // Data source for the layer.
   source: AnySourceData;
+  // Whether it should be selectable in the searchbar.
+  visibleInSearchBar: boolean;
 }
 
 /**
@@ -105,6 +107,7 @@ export enum FeaturePropertyDataType {
  */
 export enum MapLayer {
   Unknown = 'unknown',
+  LeadServiceLineByParcel = 'lead-service-lines-by-parcel',
   LeadServiceLineByWaterSystem = 'lead-service-lines-by-water-system',
   LeadAndCopperRuleViolationsByWaterSystem = 'epa-lead-and-copper-violations-by-water-system',
   PopulationByCensusBlock = 'population-by-census-block',


### PR DESCRIPTION
## Description

Addresses: 
- [Display parcel level LSL prediction data for Toledo on the map](https://app.shortcut.com/blueconduit/story/5150/display-parcel-level-lsl-prediction-data-for-toledo-on-the-map)
- [Complete data transformation](https://app.shortcut.com/blueconduit/story/5678/complete-data-transformation)

Switches lead connections data layer to point to:
- Lead connections function source for zoom < 12 (zoomed further out). This provides aggregation over state level when zoom < 6.
- Parcels when zoom > 12 (zoomed far in). 

Modifies popups + legends accordingly.

### New

- Data layer for parcels data. 

### Changed

- Zoom listener which toggles source of lead connections layer between water systems data + parcel data. This visual layer is not selectable in the search bar. 

### Removed

- N/A

## Testing and Reviewing

run with npm run serve and view lead connections. 

Initially you should see states. Zoom further to see water systems. Search 'Toledo, OH' and zoom in a bit further to see parcel data. 

## Screenshot

https://screenshot.googleplex.com/5Fsji9cCyz4BUFn
https://screenshot.googleplex.com/8rtkYi4H4uXJaNS
https://screenshot.googleplex.com/9UrQJunacNvbmMJ