### PR TITLE
Remove VPC artifact from previous code.

### DIFF
--- a/cdk/cdk.context.json
+++ b/cdk/cdk.context.json
@@ -1,9 +1,4 @@
 {
-  "availability-zones:account=036999211278:region=us-east-2": [
-    "us-east-2a",
-    "us-east-2b",
-    "us-east-2c"
-  ],
   "vpc-provider:account=036999211278:filter.vpc-id=vpc-03af3621549e79f22:region=us-east-2:returnAsymmetricSubnets=true": {
     "vpcId": "vpc-03af3621549e79f22",
     "vpcCidrBlock": "10.0.0.0/16",

--- a/cdk/cdk.context.json
+++ b/cdk/cdk.context.json
@@ -4,49 +4,6 @@
     "us-east-2b",
     "us-east-2c"
   ],
-  "vpc-provider:account=036999211278:filter.tag:Project=OpenDataPlatform:region=us-east-2:returnAsymmetricSubnets=true": {
-    "vpcId": "vpc-097e632ae8001f1bd",
-    "vpcCidrBlock": "10.0.0.0/16",
-    "availabilityZones": [],
-    "subnetGroups": [
-      {
-        "name": "public",
-        "type": "Public",
-        "subnets": [
-          {
-            "subnetId": "subnet-07d205c17acdc5306",
-            "cidr": "10.0.0.0/24",
-            "availabilityZone": "us-east-2a",
-            "routeTableId": "rtb-0c737166b00ebe664"
-          },
-          {
-            "subnetId": "subnet-0f171956a84d69313",
-            "cidr": "10.0.1.0/24",
-            "availabilityZone": "us-east-2b",
-            "routeTableId": "rtb-085656e962fb6f87a"
-          }
-        ]
-      },
-      {
-        "name": "private",
-        "type": "Private",
-        "subnets": [
-          {
-            "subnetId": "subnet-079e7278eb3086bc9",
-            "cidr": "10.0.16.0/20",
-            "availabilityZone": "us-east-2a",
-            "routeTableId": "rtb-0909508e91d56eb37"
-          },
-          {
-            "subnetId": "subnet-0f3064263a916aecf",
-            "cidr": "10.0.32.0/20",
-            "availabilityZone": "us-east-2b",
-            "routeTableId": "rtb-0298db850cb3eaf78"
-          }
-        ]
-      }
-    ]
-  },
   "vpc-provider:account=036999211278:filter.vpc-id=vpc-03af3621549e79f22:region=us-east-2:returnAsymmetricSubnets=true": {
     "vpcId": "vpc-03af3621549e79f22",
     "vpcCidrBlock": "10.0.0.0/16",


### PR DESCRIPTION
## Description

This file is autogenerated when the CDK code runs and has to make a call to AWS (such as during the VPC lookup I recently added). However, it still had the weird old VPC from the first version of that code. So this PR removes it.