### PR TITLE
Reorder table declarations to match dependency order.

### DIFF
--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -30,6 +30,37 @@ $$ LANGUAGE plpgsql;
 -- Tables --
 ------------
 
+-- States
+CREATE TABLE IF NOT EXISTS states
+(
+    census_geo_id varchar(255) NOT NULL,
+    fips          varchar(255) UNIQUE,
+    ansi          varchar(255),
+    aff_geo_id    varchar(255),
+    usps          varchar(255),
+    name          varchar(255),
+    lsad          varchar(255),
+    geom          GEOMETRY(Geometry, 4326),
+    PRIMARY KEY (census_geo_id)
+);
+
+CREATE INDEX IF NOT EXISTS geom_index ON states USING GIST (geom);
+
+-- Counties
+CREATE TABLE IF NOT EXISTS counties
+(
+    census_geo_id varchar(255) NOT NULL,
+    fips          varchar(255) NOT NULL,
+    state_fips    varchar(255) NOT NULL references states (fips),
+    ansi          varchar(255) NOT NULL,
+    aff_geo_id    varchar(255),
+    name          varchar(255),
+    lsad          varchar(255),
+    geom          geometry(Geometry, 4326),
+    PRIMARY KEY (census_geo_id)
+);
+CREATE INDEX IF NOT EXISTS geom_index ON counties USING GIST (geom);
+
 -- Census-block-level data. TODO: consider renaming the table.
 
 CREATE TABLE IF NOT EXISTS demographics
@@ -120,37 +151,6 @@ CREATE TRIGGER update_last_update_timestamp
     ON parcels
     FOR EACH ROW
 EXECUTE PROCEDURE update_last_update_timestamp();
-
--- States
-CREATE TABLE IF NOT EXISTS states
-(
-    census_geo_id varchar(255) NOT NULL,
-    fips          varchar(255) UNIQUE,
-    ansi          varchar(255),
-    aff_geo_id    varchar(255),
-    usps          varchar(255),
-    name          varchar(255),
-    lsad          varchar(255),
-    geom          GEOMETRY(Geometry, 4326),
-    PRIMARY KEY (census_geo_id)
-);
-
-CREATE INDEX IF NOT EXISTS geom_index ON states USING GIST (geom);
-
--- Counties
-CREATE TABLE IF NOT EXISTS counties
-(
-    census_geo_id varchar(255) NOT NULL,
-    fips          varchar(255) NOT NULL,
-    state_fips    varchar(255) NOT NULL references states (fips),
-    ansi          varchar(255) NOT NULL,
-    aff_geo_id    varchar(255),
-    name          varchar(255),
-    lsad          varchar(255),
-    geom          geometry(Geometry, 4326),
-    PRIMARY KEY (census_geo_id)
-);
-CREATE INDEX IF NOT EXISTS geom_index ON counties USING GIST (geom);
 
 -- Zipcodes
 CREATE TABLE IF NOT EXISTS zipcodes


### PR DESCRIPTION
## Description

The dev environment failed to run the schema lambda, which would create all of the tables for the first time. However, it was getting the following error:

```
{
    "errorType": "error",
    "errorMessage": "relation \"states\" does not exist",
    "code": "42P01",
    "length": 104,
    "name": "error",
    "severity": "ERROR",
    "file": "namespace.c",
    "line": "408",
    "routine": "RangeVarGetRelidExtended",
    "stack": [
        "error: relation \"states\" does not exist",
        "    at handleError (/var/task/node_modules/@databases/pg/lib/Driver.js:397:29)",
        "    at executeQueryInternal (/var/task/node_modules/@databases/pg/lib/Driver.js:369:9)",
        "    at processTicksAndRejections (internal/process/task_queues.js:95:5)",
        "    at async PgDriver._executeQuery (/var/task/node_modules/@databases/pg/lib/Driver.js:199:29)",
        "    at async PgDriver.executeAndReturnLast (/var/task/node_modules/@databases/pg/lib/Driver.js:224:13)",
        "    at async queryInternal (/var/task/node_modules/@databases/shared/lib/utils.js:34:25)",
        "    at async ConnectionPool._withDriverFromPool (/var/task/node_modules/@databases/shared/lib/BaseConnectionPool.js:19:28)",
        "    at async runSchemaFile (/var/task/index.js:15599:10)",
        "    at async Runtime.handler (/var/task/index.js:15544:5)"
    ]
}
```

This PR fixes this by reordering the table declarations so `states` and `counties` are created before they are referenced.