### PR TITLE
Dynamically render legend based on zoom

### DIFF
--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -172,8 +172,8 @@ CREATE TABLE IF NOT EXISTS state_demographics
 (
     census_geo_id         varchar(255) NOT NULL,
     name                  varchar(255) NOT NULL,
-    black_population      float,
-    white_population      float,
+    black_population      real,
+    white_population      real,
     total_population      real,
     under_five_population real,
     poverty_population    real,

--- a/client/src/components/MapLegend.vue
+++ b/client/src/components/MapLegend.vue
@@ -46,9 +46,13 @@ export default defineComponent({
      * bucketMap is updated.
      */
     createLegend(): void {
-      this.title = this.state.currentDataLayer?.legendInfo?.title ?? '';
+      if (this.state.map == null || this.state.currentDataLayer == null) {
+        return;
+      }
+      const geographicLevel = getGeographicLevelForZoom(Math.floor(this.state.map.getZoom()));
 
-      this.displayedBuckets = formatLegendBucket(this.state.currentDataLayer?.legendInfo);
+      this.title = this.state.currentDataLayer.legendInfo.get(geographicLevel)?.title ?? '';
+      this.displayedBuckets = formatLegendBucket(this.state.currentDataLayer.legendInfo.get(geographicLevel));
     },
   },
   mounted() {
@@ -63,6 +67,7 @@ export default defineComponent({
      */
     state: {
       handler(newState: State): void {
+        console.log(`new state ${newState?.map?.getZoom()}`);
         if (newState.currentDataLayer != null) {
           this.createLegend();
         }

--- a/client/src/components/MapLegend.vue
+++ b/client/src/components/MapLegend.vue
@@ -16,7 +16,7 @@ import { defineComponent, inject } from 'vue';
 import { State } from '../model/state';
 import { stateKey } from '../injection_keys';
 import { LegendBucketData } from '../model/data_layer';
-import { formatLegendBucket } from '../util/data_layer_util';
+import { formatLegendBucket, getGeographicLevelForZoom } from '../util/data_layer_util';
 
 /**
  * Map legend component.
@@ -49,8 +49,8 @@ export default defineComponent({
       if (this.state.map == null || this.state.currentDataLayer == null) {
         return;
       }
+      
       const geographicLevel = getGeographicLevelForZoom(Math.floor(this.state.map.getZoom()));
-
       this.title = this.state.currentDataLayer.legendInfo.get(geographicLevel)?.title ?? '';
       this.displayedBuckets = formatLegendBucket(this.state.currentDataLayer.legendInfo.get(geographicLevel));
     },
@@ -67,7 +67,6 @@ export default defineComponent({
      */
     state: {
       handler(newState: State): void {
-        console.log(`new state ${newState?.map?.getZoom()}`);
         if (newState.currentDataLayer != null) {
           this.createLegend();
         }

--- a/client/src/data_layer_configs/lead_and_copper_violations_by_water_system_config.ts
+++ b/client/src/data_layer_configs/lead_and_copper_violations_by_water_system_config.ts
@@ -37,17 +37,19 @@ const LEGEND_VALUES = [
   },
 ];
 
-const createLegends = (): Map<GeographicLevel, LegendInfo> => {
-  const stateLegendInfo = {
-    title: 'Percentage of service lines estimated to be lead',
-    buckets: LEGEND_VALUES,
-    bucketLabelType: FeaturePropertyDataType.Number,
-  };
-  // The only aggregations for violations is state.
-  // Because the legend is shown in percentages, the legend does not need to
-  // change at higher zooms.
-  return new Map([[GeographicLevel.State, stateLegendInfo]]);
-};
+// The only aggregations for violations is state.
+// Because the legend is shown in percentages, the legend does not need to
+// change at higher zooms.
+const legend = new Map([
+  [
+    GeographicLevel.State,
+    {
+      title: 'Percentage of service lines estimated to be lead',
+      buckets: LEGEND_VALUES,
+      bucketLabelType: FeaturePropertyDataType.Number,
+    },
+  ],
+]);
 
 /**
  * Mapbox expression which interpolates pairs of bucket 'stops' + colors to produce continuous
@@ -107,7 +109,7 @@ export const leadAndCopperViolationsByCountyDataLayer: TileDataLayer = {
   },
   id: MapLayer.LeadAndCopperRuleViolationsByWaterSystem,
   name: 'Lead & Copper Rule Violations',
-  legendInfo: createLegends(),
+  legendInfo: legend,
   popupInfo: popupInfo,
   styleLayer: styleLayer,
   visibleInSearchBar: true,

--- a/client/src/data_layer_configs/lead_and_copper_violations_by_water_system_config.ts
+++ b/client/src/data_layer_configs/lead_and_copper_violations_by_water_system_config.ts
@@ -35,7 +35,7 @@ const LEGEND_VALUES = [
 
 const createLegends = (): Map<GeographicLevel, LegendInfo> => {
   const stateLegendInfo = {
-    title: 'Number of violations',
+    title: 'Percent of service lines estimated to be lead',
     buckets: LEGEND_VALUES,
     bucketLabelType: FeaturePropertyDataType.Number,
   };

--- a/client/src/data_layer_configs/lead_and_copper_violations_by_water_system_config.ts
+++ b/client/src/data_layer_configs/lead_and_copper_violations_by_water_system_config.ts
@@ -1,6 +1,7 @@
 import {
   DataSourceType,
   FeaturePropertyDataType,
+  GeographicLevel,
   LegendInfo,
   MapLayer,
   PopupInfo,
@@ -32,6 +33,21 @@ const LEGEND_VALUES = [
   },
 ];
 
+const createLegends = (): Map<GeographicLevel, LegendInfo> => {
+  const stateLegendInfo = {
+    title: 'Number of violations',
+    buckets: LEGEND_VALUES,
+    bucketLabelType: FeaturePropertyDataType.Number,
+  };
+
+  return new Map([
+    [GeographicLevel.State, stateLegendInfo],
+    [GeographicLevel.County, stateLegendInfo],
+    [GeographicLevel.Zipcode, stateLegendInfo],
+    [GeographicLevel.Parcel, stateLegendInfo],
+  ]);
+};
+
 /**
  * Mapbox expression which interpolates pairs of bucket 'stops' + colors to produce continuous
  * results for the map.
@@ -44,12 +60,6 @@ const leadAndCopperViolationsInterpolation: Expression = [
   ['get', 'violation_count'],
   ...getLegendBucketsAsList(LEGEND_VALUES),
 ];
-
-const legendInfo: LegendInfo = {
-  title: 'Number of violations',
-  buckets: LEGEND_VALUES,
-  bucketLabelType: FeaturePropertyDataType.Number,
-};
 
 const styleLayer: FillLayer = {
   id: `${MapLayer.LeadAndCopperRuleViolationsByWaterSystem}-style`,
@@ -91,7 +101,7 @@ export const leadAndCopperViolationsByCountyDataLayer: TileDataLayer = {
   },
   id: MapLayer.LeadAndCopperRuleViolationsByWaterSystem,
   name: 'Lead & Copper Rule Violations',
-  legendInfo: legendInfo,
+  legendInfo: createLegends(),
   popupInfo: popupInfo,
   styleLayer: styleLayer,
 };

--- a/client/src/data_layer_configs/lead_and_copper_violations_by_water_system_config.ts
+++ b/client/src/data_layer_configs/lead_and_copper_violations_by_water_system_config.ts
@@ -39,11 +39,13 @@ const LEGEND_VALUES = [
 
 const createLegends = (): Map<GeographicLevel, LegendInfo> => {
   const stateLegendInfo = {
-    title: 'Percent of service lines estimated to be lead',
+    title: 'Percentage of service lines estimated to be lead',
     buckets: LEGEND_VALUES,
     bucketLabelType: FeaturePropertyDataType.Number,
   };
-
+  // The only aggregations for violations is state.
+  // Because the legend is shown in percentages, the legend does not need to
+  // change at higher zooms.
   return new Map([[GeographicLevel.State, stateLegendInfo]]);
 };
 

--- a/client/src/data_layer_configs/lead_service_lines_by_parcel_config.ts
+++ b/client/src/data_layer_configs/lead_service_lines_by_parcel_config.ts
@@ -38,15 +38,16 @@ const LEGEND_VALUES = [
   },
 ];
 
-const createLegends = (): Map<GeographicLevel, LegendInfo> => {
-  const parcelLegendInfo = {
-    title: 'Percentage of service lines estimated to be lead',
-    buckets: LEGEND_VALUES,
-    bucketLabelType: FeaturePropertyDataType.Percentage,
-  };
-
-  return new Map([[GeographicLevel.Parcel, parcelLegendInfo]]);
-};
+const legend = new Map([
+  [
+    GeographicLevel.Parcel,
+    {
+      title: 'Percentage of service lines estimated to be lead',
+      buckets: LEGEND_VALUES,
+      bucketLabelType: FeaturePropertyDataType.Percentage,
+    },
+  ],
+]);
 
 const percentLeadLikelihood = ['*', 100, ['get', 'public_lead_prediction']];
 
@@ -110,7 +111,7 @@ export const leadServiceLinesByParcelLayer: TileDataLayer = {
   },
   id: MapLayer.LeadServiceLineByParcel,
   name: 'Lead Service Line Estimate (Home)',
-  legendInfo: createLegends(),
+  legendInfo: legend,
   popupInfo: popupInfo,
   styleLayer: styleLayer,
   visibleInSearchBar: false,

--- a/client/src/data_layer_configs/lead_service_lines_by_parcel_config.ts
+++ b/client/src/data_layer_configs/lead_service_lines_by_parcel_config.ts
@@ -38,6 +38,16 @@ const LEGEND_VALUES = [
   },
 ];
 
+const createLegends = (): Map<GeographicLevel, LegendInfo> => {
+  const stateLegendInfo = {
+    title: 'Percent of service lines estimated to be lead',
+    buckets: LEGEND_VALUES,
+    bucketLabelType: FeaturePropertyDataType.Percentage,
+  };
+
+  return new Map([[GeographicLevel.County, stateLegendInfo]]);
+};
+
 const percentLeadLikelihood = ['*', 100, ['get', 'public_lead_prediction']];
 
 /**
@@ -53,16 +63,6 @@ const leadConnectionLegendInterpolation = [
   percentLeadLikelihood,
   ...getLegendBucketsAsList(LEGEND_VALUES),
 ];
-
-const createLegends = (): Map<GeographicLevel, LegendInfo> => {
-  const stateLegendInfo = {
-    title: 'Percent of service lines estimated to be lead',
-    buckets: LEGEND_VALUES,
-    bucketLabelType: FeaturePropertyDataType.Percentage,
-  };
-
-  return new Map([[GeographicLevel.County, stateLegendInfo]]);
-};
 
 export const styleLayer: FillLayer = {
   id: `${MapLayer.LeadServiceLineByParcel}-style`,

--- a/client/src/data_layer_configs/lead_service_lines_by_parcel_config.ts
+++ b/client/src/data_layer_configs/lead_service_lines_by_parcel_config.ts
@@ -39,13 +39,13 @@ const LEGEND_VALUES = [
 ];
 
 const createLegends = (): Map<GeographicLevel, LegendInfo> => {
-  const stateLegendInfo = {
+  const parcelLegendInfo = {
     title: 'Percent of service lines estimated to be lead',
     buckets: LEGEND_VALUES,
     bucketLabelType: FeaturePropertyDataType.Percentage,
   };
-
-  return new Map([[GeographicLevel.County, stateLegendInfo]]);
+  
+  return new Map([[GeographicLevel.Parcel, parcelLegendInfo]]);
 };
 
 const percentLeadLikelihood = ['*', 100, ['get', 'public_lead_prediction']];

--- a/client/src/data_layer_configs/lead_service_lines_by_parcel_config.ts
+++ b/client/src/data_layer_configs/lead_service_lines_by_parcel_config.ts
@@ -40,11 +40,11 @@ const LEGEND_VALUES = [
 
 const createLegends = (): Map<GeographicLevel, LegendInfo> => {
   const parcelLegendInfo = {
-    title: 'Percent of service lines estimated to be lead',
+    title: 'Percentage of service lines estimated to be lead',
     buckets: LEGEND_VALUES,
     bucketLabelType: FeaturePropertyDataType.Percentage,
   };
-  
+
   return new Map([[GeographicLevel.Parcel, parcelLegendInfo]]);
 };
 

--- a/client/src/data_layer_configs/lead_service_lines_by_water_systems_config.ts
+++ b/client/src/data_layer_configs/lead_service_lines_by_water_systems_config.ts
@@ -1,6 +1,7 @@
 import {
   DataSourceType,
   FeaturePropertyDataType,
+  GeographicLevel,
   LegendInfo,
   MapLayer,
   PopupInfo,
@@ -39,6 +40,21 @@ const LEGEND_VALUES = [
   },
 ];
 
+const createLegends = (): Map<GeographicLevel, LegendInfo> => {
+  const stateLegendInfo = {
+    title: 'Percent of service lines estimated to be lead',
+    buckets: LEGEND_VALUES,
+    bucketLabelType: FeaturePropertyDataType.Percentage,
+  };
+
+  return new Map([
+    [GeographicLevel.State, stateLegendInfo],
+    [GeographicLevel.County, stateLegendInfo],
+    [GeographicLevel.Zipcode, stateLegendInfo],
+    [GeographicLevel.Parcel, stateLegendInfo],
+  ]);
+};
+
 const percentLeadLines = [
   '*',
   100,
@@ -58,12 +74,6 @@ const leadConnectionLegendInterpolation = [
   percentLeadLines,
   ...getLegendBucketsAsList(LEGEND_VALUES),
 ];
-
-const legendInfo: LegendInfo = {
-  title: 'Percent of service lines estimated to be lead',
-  buckets: LEGEND_VALUES,
-  bucketLabelType: FeaturePropertyDataType.Percentage,
-};
 
 export const styleLayer: FillLayer = {
   id: `${MapLayer.LeadServiceLineByWaterSystem}-style`,
@@ -124,7 +134,7 @@ export const leadServiceLinesByWaterSystemLayer: TileDataLayer = {
   },
   id: MapLayer.LeadServiceLineByWaterSystem,
   name: 'Lead Service Lines',
-  legendInfo: legendInfo,
+  legendInfo: createLegends(),
   popupInfo: popupInfo,
   styleLayer: styleLayer,
 };

--- a/client/src/data_layer_configs/lead_service_lines_by_water_systems_config.ts
+++ b/client/src/data_layer_configs/lead_service_lines_by_water_systems_config.ts
@@ -42,7 +42,7 @@ const LEGEND_VALUES = [
 
 const createLegends = (): Map<GeographicLevel, LegendInfo> => {
   const legendInfo = {
-    title: 'Percent of service lines estimated to be lead',
+    title: 'Percentage of service lines estimated to be lead',
     buckets: LEGEND_VALUES,
     bucketLabelType: FeaturePropertyDataType.Percentage,
   };

--- a/client/src/data_layer_configs/lead_service_lines_by_water_systems_config.ts
+++ b/client/src/data_layer_configs/lead_service_lines_by_water_systems_config.ts
@@ -41,12 +41,16 @@ const LEGEND_VALUES = [
 ];
 
 const createLegends = (): Map<GeographicLevel, LegendInfo> => {
-  const waterSystemLegendInfo = {
+  const legendInfo = {
     title: 'Percent of service lines estimated to be lead',
     buckets: LEGEND_VALUES,
     bucketLabelType: FeaturePropertyDataType.Percentage,
   };
-  return new Map([[GeographicLevel.State, waterSystemLegendInfo]]);
+
+  // The only aggregations for water system is state.
+  // Because the legend is shown in percentages, the legend does not need to
+  // change at higher zooms.
+  return new Map([[GeographicLevel.State, legendInfo]]);
 };
 
 const percentLeadLines = [

--- a/client/src/data_layer_configs/lead_service_lines_by_water_systems_config.ts
+++ b/client/src/data_layer_configs/lead_service_lines_by_water_systems_config.ts
@@ -40,18 +40,19 @@ const LEGEND_VALUES = [
   },
 ];
 
-const createLegends = (): Map<GeographicLevel, LegendInfo> => {
-  const legendInfo = {
-    title: 'Percentage of service lines estimated to be lead',
-    buckets: LEGEND_VALUES,
-    bucketLabelType: FeaturePropertyDataType.Percentage,
-  };
-
-  // The only aggregations for water system is state.
-  // Because the legend is shown in percentages, the legend does not need to
-  // change at higher zooms.
-  return new Map([[GeographicLevel.State, legendInfo]]);
-};
+// The only aggregations for water system is state.
+// Because the legend is shown in percentages, the legend does not need to
+// change at higher zooms.
+const legend = new Map([
+  [
+    GeographicLevel.State,
+    {
+      title: 'Percentage of service lines estimated to be lead',
+      buckets: LEGEND_VALUES,
+      bucketLabelType: FeaturePropertyDataType.Percentage,
+    },
+  ],
+]);
 
 const percentLeadLines = [
   '*',
@@ -139,7 +140,7 @@ export const leadServiceLinesByWaterSystemLayer: TileDataLayer = {
   },
   id: MapLayer.LeadServiceLineByWaterSystem,
   name: 'Lead Service Lines',
-  legendInfo: createLegends(),
+  legendInfo: legend,
   popupInfo: popupInfo,
   styleLayer: styleLayer,
   visibleInSearchBar: true,

--- a/client/src/data_layer_configs/population_by_census_block_config.ts
+++ b/client/src/data_layer_configs/population_by_census_block_config.ts
@@ -1,6 +1,7 @@
 import {
   DataSourceType,
   FeaturePropertyDataType,
+  GeographicLevel,
   LegendInfo,
   MapLayer,
   PopupInfo,
@@ -43,7 +44,7 @@ const LEGEND_VALUES_STATES = [
 
 // TODO (breuch): automate this. Right now the mathematical relationship
 // between LEGEND_VALUES_STATES and LEGEND_VALUES_COUNTY is not yet clear.
-export const LEGEND_VALUES_COUNTY = [
+const LEGEND_VALUES_COUNTY = [
   {
     bucketValue: 0,
     bucketColor: '#D1E4F2',
@@ -70,10 +71,22 @@ export const LEGEND_VALUES_COUNTY = [
   },
 ];
 
-const legendInfo: LegendInfo = {
-  title: 'U.S. Census data',
-  buckets: LEGEND_VALUES_STATES,
-  bucketLabelType: FeaturePropertyDataType.Number,
+const createLegends = (): Map<GeographicLevel, LegendInfo> => {
+  const stateLegendInfo = {
+    title: 'U.S. Census data',
+    buckets: LEGEND_VALUES_STATES,
+    bucketLabelType: FeaturePropertyDataType.Number,
+  };
+
+  const countyLegendInfo = { ...stateLegendInfo };
+  countyLegendInfo.buckets = LEGEND_VALUES_COUNTY;
+
+  return new Map([
+    [GeographicLevel.State, stateLegendInfo],
+    [GeographicLevel.County, countyLegendInfo],
+    [GeographicLevel.Zipcode, countyLegendInfo],
+    [GeographicLevel.Parcel, countyLegendInfo],
+  ]);
 };
 
 const nullInterpolation = ['case', ['==', ['get', 'total_population'], null], DEFAULT_NULL_COLOR];
@@ -95,7 +108,7 @@ const legendInterpolationCounty = [
   [...totalPopulationInterpolation, ...getLegendBucketsAsList(LEGEND_VALUES_COUNTY)],
 ];
 
-export const styleLayer: FillLayer = {
+const styleLayer: FillLayer = {
   id: `${MapLayer.PopulationByCensusBlock}-style`,
   source: MapLayer.PopulationByCensusBlock,
   // Corresponds to the table in the database.
@@ -114,7 +127,7 @@ export const styleLayer: FillLayer = {
       legendInterpolationCounty,
     ],
     'fill-opacity': 0.75,
-    'fill-outline-color': '#6433FF',
+    'fill-outline-color': '#0B2553',
   },
   layout: {
     // Make the layer hidden by default.
@@ -167,8 +180,7 @@ export const populationDataByCensusBlockLayer: TileDataLayer = {
   },
   id: MapLayer.PopulationByCensusBlock,
   name: 'Population',
-  // TODO (breuch): Update based on zoom.
-  legendInfo: legendInfo,
+  legendInfo: createLegends(),
   popupInfo: popupInfo,
   styleLayer: styleLayer,
 };

--- a/client/src/model/data_layer.ts
+++ b/client/src/model/data_layer.ts
@@ -7,7 +7,7 @@ import { AnyLayer, AnySourceData, FillLayer, VectorSource } from 'mapbox-gl';
  * number of lead service lines per water system. The DataLayer interface contains fields that
  * configure how the data is sourced and rendered on the map.
  */
-export interface DataLayer {
+interface DataLayer {
   // Unique ID used to identify data layer in mapbox source and style configs.
   id: string;
   // Name of this data layer that is displayed in search bar.
@@ -15,7 +15,7 @@ export interface DataLayer {
   // Layer which specifies the styling of this data layer.
   styleLayer: FillLayer;
   // Information to display in the map legend when this layer is visible.
-  legendInfo: LegendInfo;
+  legendInfo: Map<GeographicLevel, LegendInfo>;
   // Information to display in the map popup when this layer is visible and the user interacts with
   // the map.
   popupInfo: PopupInfo;
@@ -26,7 +26,7 @@ export interface DataLayer {
 /**
  * Data layers where the source is a tile server,
  */
-export interface TileDataLayer extends DataLayer {
+interface TileDataLayer extends DataLayer {
   // The endpoint to the tileserver.
   source: VectorSource;
 }
@@ -34,7 +34,7 @@ export interface TileDataLayer extends DataLayer {
 /**
  * Determines how to display a legend bucket
  */
-export interface LegendBucketData {
+interface LegendBucketData {
   // Bucket color hex value.
   bucketColor: string;
   // Formatted label for bucket value.
@@ -46,7 +46,7 @@ export interface LegendBucketData {
 /**
  * Information to be displayed in the map legend when this layer is visible.
  */
-export interface LegendInfo {
+interface LegendInfo {
   // Legend title.
   title: string;
   // Key / value map of visual representation -> values to be displayed in the legend.
@@ -59,7 +59,7 @@ export interface LegendInfo {
  * Information to be displayed in the map popup when this layer is visible and the user clicks the
  * map.
  */
-export interface PopupInfo {
+interface PopupInfo {
   // Popup title.
   title: string;
   // Popup subtitle.
@@ -70,7 +70,7 @@ export interface PopupInfo {
   featureProperties: FeatureProperty[];
 }
 
-export interface FeatureProperty {
+interface FeatureProperty {
   // Label that is displayed when this property is displayed in the UI.
   label: string;
   // Name of this feature property.
@@ -83,7 +83,7 @@ export interface FeatureProperty {
  * Data source type. Required by Mapbox.
  * See: https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/
  */
-export enum DataSourceType {
+enum DataSourceType {
   Unknown = 'unknown',
   Vector = 'vector',
 }
@@ -91,7 +91,7 @@ export enum DataSourceType {
 /**
  * Type for a feature property to determine how to parse it.
  */
-export enum FeaturePropertyDataType {
+enum FeaturePropertyDataType {
   Unknown = 'unknown',
   String = 'string',
   Number = 'number',
@@ -103,9 +103,34 @@ export enum FeaturePropertyDataType {
 /**
  * Identifiers for map layers.
  */
-export enum MapLayer {
+enum MapLayer {
   Unknown = 'unknown',
   LeadServiceLineByWaterSystem = 'lead-service-lines-by-water-system',
   LeadAndCopperRuleViolationsByWaterSystem = 'epa-lead-and-copper-violations-by-water-system',
   PopulationByCensusBlock = 'population-by-census-block',
 }
+
+/**
+ * Zoom levels for each demographic layer.
+ * This needs to be kept in order.
+ */
+enum GeographicLevel {
+  Unknown = 0,
+  State = 4,
+  County = 5,
+  Zipcode = 6,
+  Parcel = 9,
+}
+
+export {
+  DataLayer,
+  DataSourceType,
+  FeatureProperty,
+  FeaturePropertyDataType,
+  GeographicLevel,
+  LegendBucketData,
+  LegendInfo,
+  MapLayer,
+  PopupInfo,
+  TileDataLayer,
+};

--- a/client/src/util/data_layer_util.ts
+++ b/client/src/util/data_layer_util.ts
@@ -1,10 +1,15 @@
-import { FeaturePropertyDataType, LegendBucketData, LegendInfo } from '@/model/data_layer';
+import {
+  FeaturePropertyDataType,
+  GeographicLevel,
+  LegendBucketData,
+  LegendInfo,
+} from '@/model/data_layer';
 
 /**
  * Adds a bucketLabel to a legends bucket based on its data type.
  * @param legend: has information on the data type for the buckets.
  */
-export const formatLegendBucket = (legend: LegendInfo | undefined): Array<LegendBucketData> => {
+const formatLegendBucket = (legend: LegendInfo | undefined): Array<LegendBucketData> => {
   legend?.buckets?.forEach((bucket) => {
     switch (legend.bucketLabelType) {
       case FeaturePropertyDataType.String: {
@@ -29,12 +34,21 @@ export const formatLegendBucket = (legend: LegendInfo | undefined): Array<Legend
 };
 
 /**
+ * Return the [GeographicLevel] for a given zoom value.
+ * @param zoom: zoom level. Each geographic level enum is inherently
+ * assigned to an enum value.
+ */
+const getGeographicLevelForZoom = (zoom: number): GeographicLevel => {
+  return GeographicLevel[`${zoom}`] as GeographicLevel;
+};
+
+/**
  * The "interpolate" expression in Mapbox requires number: color formatting
  * to identify buckets
  * https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/#interpolate
  * @param buckets to use for interpolation.
  */
-export const getLegendBucketsAsList = (buckets: LegendBucketData[]): Array<any> => {
+const getLegendBucketsAsList = (buckets: LegendBucketData[]): Array<any> => {
   const bucketToValues = [];
   for (const bucket of buckets) {
     bucketToValues.push(bucket.bucketValue, bucket.bucketColor);
@@ -49,8 +63,10 @@ const LOCALHOST = 'localhost';
  *
  * Returns location.hostname unless app is being run locally.
  */
-export function tileServerHost() {
+function tileServerHost() {
   return location.hostname == LOCALHOST
     ? process.env.VUE_APP_DEFAULT_TILESERVER_HOST
     : location.hostname;
 }
+
+export { formatLegendBucket, getGeographicLevelForZoom, getLegendBucketsAsList, tileServerHost };

--- a/client/src/util/data_layer_util.ts
+++ b/client/src/util/data_layer_util.ts
@@ -43,13 +43,10 @@ const getLegendForZoomLevel = (
   legends: Map<GeographicLevel, LegendInfo>,
   zoom: number,
 ): LegendInfo | undefined => {
-  // Object.values().reverse() gives
-  // [9, 6, 5, 4, 0, "Parcel", "Zipcode", "County", "State", "Unknown"]
   // This looks for the first qualifying zoom.
   const mostGranularLegendForZoom = Object.values(GeographicLevel)
     .reverse()
     .find((level) => level <= zoom && legends.has(level as GeographicLevel)) as GeographicLevel;
-  console.log(mostGranularLegendForZoom);
   return legends.get(mostGranularLegendForZoom);
 };
 

--- a/client/src/util/data_layer_util.ts
+++ b/client/src/util/data_layer_util.ts
@@ -39,7 +39,12 @@ const formatLegendBucket = (legend: LegendInfo | undefined): Array<LegendBucketD
  * assigned to an enum value.
  */
 const getGeographicLevelForZoom = (zoom: number): GeographicLevel => {
-  return GeographicLevel[`${zoom}`] as GeographicLevel;
+  // Object.values().reverse() gives
+  // ["Unknown", "State", "County", "Zipcode", "Parcel", 0, 4, 5, 6, 9]
+  // This looks for the first qualifying zoom.
+  return Object.values(GeographicLevel)
+    .reverse()
+    .find((layer) => layer <= zoom) as GeographicLevel;
 };
 
 /**


### PR DESCRIPTION
## Description

Addresses: [Complete data transformation](https://app.shortcut.com/blueconduit/story/5678/complete-data-transformation)

Changes the legend buckets based on zoom level. 

### New

GeographicLevel enum which maps a geo to a zoom level upon which you see the that geo-based aggregation

### Changed

LegendInfo is now a map that contains a legend for each supported geo

## Testing and Reviewing

UI
