### PR TITLE
Add title metadata based on route.

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -2,8 +2,9 @@
   <NavigationBar />
 </template>
 
-<script lang='ts'>
+<script lang="ts">
 import { defineComponent, provide, reactive } from 'vue';
+import { RouteLocation } from 'vue-router';
 import '@blueconduit/copper/dist/css/copper.css';
 import NavigationBar from './components/NavigationBar.vue';
 import { State } from './model/state';
@@ -15,6 +16,7 @@ import { populationDataByCensusBlockLayer } from './data_layer_configs/populatio
 import { leadAndCopperViolationsByCountyDataLayer } from './data_layer_configs/lead_and_copper_violations_by_water_system_config';
 import { leadServiceLinesByParcelLayer } from './data_layer_configs/lead_service_lines_by_parcel_config';
 
+const DEFAULT_TITLE = 'LeadOut';
 const DATA_LAYERS = new Map<MapLayer, DataLayer>([
   [MapLayer.LeadServiceLineByWaterSystem, leadServiceLinesByWaterSystemLayer],
   [MapLayer.LeadAndCopperRuleViolationsByWaterSystem, leadAndCopperViolationsByCountyDataLayer],
@@ -41,9 +43,15 @@ export default defineComponent({
       state,
     };
   },
+  watch: {
+    $route(to: RouteLocation) {
+      // TODO: consider adding a string that says this is a non-prod environment, so devs can see
+      // that at a glance in their browser tabs. E.g. "[sandbox] LeadOut - Home"
+      document.title = (to.meta.title as string) ?? DEFAULT_TITLE;
+    },
+  },
 });
-
 </script>
 <style>
-@import "./assets/styles/global.scss";
+@import './assets/styles/global.scss';
 </style>

--- a/client/src/router.ts
+++ b/client/src/router.ts
@@ -9,14 +9,23 @@ const routes = [
   {
     path: HOME_ROUTE,
     component: MapContentContainer,
+    meta: {
+      title: 'LeadOut - Home',
+    },
   },
   {
     path: MAP_ROUTE,
     component: MapContentContainer,
+    meta: {
+      title: 'LeadOut - Nationwide Lead Map',
+    },
   },
   {
     path: CONTACT_ROUTE,
     component: MapContentContainer,
+    meta: {
+      title: 'LeadOut - Contact Us',
+    },
   },
 ];
 


### PR DESCRIPTION
## Description

Before, we just used the default `app` title. This uses a dynamic one based on route.

### New

- Added a watcher for route changes that changes the HTML title.

## Testing and Reviewing

You can see the titles changes on https://beekley.leadout-sandbox.blueconduit.com/ and other URLs.
