### PR TITLE
Refactor geocoder into its own component

### DIFF
--- a/client/src/components/GeocoderInput.vue
+++ b/client/src/components/GeocoderInput.vue
@@ -11,7 +11,7 @@ import '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css';
  * Wrapper for Mapbox Geocoder.
  *
  * See details at https://github.com/mapbox/mapbox-gl-geocoder.
- * More details on how to use the geocoder outside of a map: https://docs.mapbox.com/mapbox-gl-js/example/mapbox-gl-geocoder-no-map/
+ * And how to use the geocoder outside of a map: https://docs.mapbox.com/mapbox-gl-js/example/mapbox-gl-geocoder-no-map/
  */
 export default defineComponent({
   name: 'GeocoderInput',
@@ -26,14 +26,17 @@ export default defineComponent({
       geocoder,
     };
   },
+  emits: {
+    result: (lat: number, long: number) => true,
+  },
   mounted() {
     this.geocoder.addTo('.geocoder');
 
     // TODO: replace 'any' here with a meaningful type.
     this.geocoder.on('result', async (result: any) => {
-      const long = result.result.center[0];
-      const lat = result.result.center[1];
-      console.log({ lat, long });
+      const long: number = result.result.center[0];
+      const lat: number = result.result.center[1];
+      this.$emit('result', lat, long);
     });
   },
 });
@@ -42,24 +45,6 @@ export default defineComponent({
 <style>
 .geocoder {
   display: inline-block;
-}
-
-.geocoder-content-collapsed {
-  height: 38px;
-  border-left: 1px solid #cccccc;
-  border-right: 1px solid #cccccc;
-}
-
-.geocoder-content-is-expanded {
-  height: 38px;
-  border: 1px solid #cccccc;
-  border-radius: 5px;
-}
-
-.search-button {
-  float: right;
-  display: inline-block;
-  padding: 10px 15px 0 15px;
 }
 
 /** Override geocoder styles. **/

--- a/client/src/components/GeocoderInput.vue
+++ b/client/src/components/GeocoderInput.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="geocoder"></div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import MapboxGeocoder from '@mapbox/mapbox-gl-geocoder';
+import '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css';
+
+/**
+ * Wrapper for Mapbox Geocoder.
+ *
+ * See details at https://github.com/mapbox/mapbox-gl-geocoder.
+ * More details on how to use the geocoder outside of a map: https://docs.mapbox.com/mapbox-gl-js/example/mapbox-gl-geocoder-no-map/
+ */
+export default defineComponent({
+  name: 'GeocoderInput',
+  data() {
+    const geocoder = new MapboxGeocoder({
+      accessToken: process.env.VUE_APP_MAP_BOX_API_TOKEN ?? '',
+      mapboxgl: undefined,
+      marker: false,
+      countries: 'US',
+    });
+    return {
+      geocoder,
+    };
+  },
+  mounted() {
+    this.geocoder.addTo('.geocoder');
+
+    // TODO: replace 'any' here with a meaningful type.
+    this.geocoder.on('result', async (result: any) => {
+      const long = result.result.center[0];
+      const lat = result.result.center[1];
+      console.log({ lat, long });
+    });
+  },
+});
+</script>
+
+<style>
+.geocoder {
+  display: inline-block;
+}
+
+.geocoder-content-collapsed {
+  height: 38px;
+  border-left: 1px solid #cccccc;
+  border-right: 1px solid #cccccc;
+}
+
+.geocoder-content-is-expanded {
+  height: 38px;
+  border: 1px solid #cccccc;
+  border-radius: 5px;
+}
+
+.search-button {
+  float: right;
+  display: inline-block;
+  padding: 10px 15px 0 15px;
+}
+
+/** Override geocoder styles. **/
+
+.mapboxgl-ctrl-geocoder {
+  box-shadow: none;
+}
+
+.mapboxgl-ctrl-geocoder--icon-search {
+  visibility: hidden;
+  width: 0;
+  height: 0;
+}
+
+.mapboxgl-ctrl-geocoder--input {
+  padding: 10px 11px;
+  line-height: 12px;
+}
+
+.mapboxgl-ctrl-geocoder--input:focus {
+  outline: none;
+}
+</style>

--- a/client/src/components/MapGeocoderWrapper.vue
+++ b/client/src/components/MapGeocoderWrapper.vue
@@ -22,9 +22,7 @@ import { State } from '../model/state';
 import { stateKey } from '../injection_keys';
 
 /**
- * Wrapper for Mapbox Geocoder.
- *
- * See details at https://github.com/mapbox/mapbox-gl-geocoder.
+ * Expandable address search that performs a geocode.
  */
 export default defineComponent({
   name: 'MapGeocoderWrapper',
@@ -38,7 +36,7 @@ export default defineComponent({
     };
   },
   props: {
-    expandSearch: { type: Boolean, default: true },
+    expandSearch: { type: Boolean, default: false },
   },
   methods: {
     async onGeocodeResults(lat: number, long: number) {

--- a/client/src/components/MapGeocoderWrapper.vue
+++ b/client/src/components/MapGeocoderWrapper.vue
@@ -1,29 +1,25 @@
 <template>
   <div>
-    <div v-show='expandSearch' class='geocoder-content-is-expanded'>
-      <div class='geocoder' id='geocoder'></div>
-      <div class='search-button'
-           @click="$emit('update:expandSearch', !this.expandSearch)">
-        <img src='@/assets/icons/search.svg' />
+    <div v-show="expandSearch" class="geocoder-content-is-expanded">
+      <GeocoderInput @result="onGeocodeResults" />
+      <div class="search-button" @click="$emit('update:expandSearch', !this.expandSearch)">
+        <img src="@/assets/icons/search.svg" />
       </div>
     </div>
-    <div v-show='!expandSearch' class='geocoder-content-collapsed'>
-      <div class='search-button'
-           @click="$emit('update:expandSearch', !this.expandSearch)">
-        <img src='@/assets/icons/search.svg' />
+    <div v-show="!expandSearch" class="geocoder-content-collapsed">
+      <div class="search-button" @click="$emit('update:expandSearch', !this.expandSearch)">
+        <img src="@/assets/icons/search.svg" />
       </div>
     </div>
   </div>
 </template>
 
-<script lang='ts'>
+<script lang="ts">
 import axios from 'axios';
 import { defineComponent, inject } from 'vue';
+import GeocoderInput from './GeocoderInput.vue';
 import { State } from '../model/state';
 import { stateKey } from '../injection_keys';
-import MapboxGeocoder from '@mapbox/mapbox-gl-geocoder';
-import '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css';
-import mapboxgl from 'mapbox-gl';
 
 /**
  * Wrapper for Mapbox Geocoder.
@@ -32,76 +28,51 @@ import mapboxgl from 'mapbox-gl';
  */
 export default defineComponent({
   name: 'MapGeocoderWrapper',
+  components: {
+    GeocoderInput,
+  },
   setup() {
     const state: State = inject(stateKey, State.default());
     return {
       state,
     };
   },
-  data() {
-    return {
-      // Default to empty geocoder instance that is not connected to map or view.
-      geocoder: new MapboxGeocoder(),
-    };
-  },
   props: {
-    expandSearch: { type: Boolean, default: false },
+    expandSearch: { type: Boolean, default: true },
   },
-  watch: {
-    'state.map': function(newMap: mapboxgl.Map) {
-      // Create geocoder when map is updated and geocoder is null. This is only triggered once per
-      // app load since the map is only created once.
-      if (newMap != null) {
-        this.geocoder = new MapboxGeocoder({
-          accessToken: process.env.VUE_APP_MAP_BOX_API_TOKEN ?? '',
-          mapboxgl: undefined,
-          marker: false,
-          countries: 'US',
-        });
+  methods: {
+    async onGeocodeResults(lat: number, long: number) {
+      console.log({ lat, long });
+      try {
+        // This gets removed in https://github.com/BlueConduit/open-data-platform/pull/77
+        const data = await axios.get<any>(
+          `https://ei2tz84crb.execute-api.us-east-2.amazonaws.com/dev/geolocate/${lat},${long}`,
+          {
+            headers: {
+              Accept: 'application/json',
+            },
+          },
+        );
 
-        this.geocoder.on('result', async (result: any) => {
-          const long = result.result.center[0];
-          const lat = result.result.center[1];
-
-          try {
-            // This gets removed in https://github.com/BlueConduit/open-data-platform/pull/77
-            const data = await axios.get<any>(
-              `https://ei2tz84crb.execute-api.us-east-2.amazonaws.com/dev/geolocate/${lat},${long}`,
-              {
-                headers: {
-                  Accept: 'application/json',
-                },
-              },
-            );
-
-            console.log(JSON.stringify(data));
-          } catch (error) {
-            console.log(error);
-          }
-        });
-
-        document.getElementById('geocoder')?.appendChild(this.geocoder.onAdd(newMap));
+        console.log(JSON.stringify(data));
+      } catch (error) {
+        console.log(error);
       }
     },
   },
 });
 </script>
 
-
 <style>
-.geocoder {
-  display: inline-block;
-}
-
 .geocoder-content-collapsed {
   height: 38px;
-  border-left: 1px solid #CCCCCC;
-  border-right: 1px solid #CCCCCC;
+  border-left: 1px solid #cccccc;
+  border-right: 1px solid #cccccc;
 }
 
 .geocoder-content-is-expanded {
   height: 38px;
-  border: 1px solid #CCCCCC;
+  border: 1px solid #cccccc;
   border-radius: 5px;
 }
 
@@ -109,26 +80,5 @@ export default defineComponent({
   float: right;
   display: inline-block;
   padding: 10px 15px 0 15px;
-}
-
-/** Override geocoder styles. **/
-
-.mapboxgl-ctrl-geocoder {
-  box-shadow: none;
-}
-
-.mapboxgl-ctrl-geocoder--icon-search {
-  visibility: hidden;
-  width: 0;
-  height: 0;
-}
-
-.mapboxgl-ctrl-geocoder--input {
-  padding: 10px 11px;
-  line-height: 12px;
-}
-
-.mapboxgl-ctrl-geocoder--input:focus {
-  outline: none;
 }
 </style>


### PR DESCRIPTION
## Description

I needed a geocoder for the landing page, but our existing `MapGeocoderWrapper` has map-specific code in it. I've broken out the geocoder input itself into its own component so it can be used outside of the map.

### New

- `GeocoderInput` component

### Changed

- `MapGeocoderWrapper` uses `GeocoderInput`, which emits the `lat,long` of the selected result.

## Testing and Reviewing

There's no functional change, since this is just a refactor.