### PR TITLE
Make geolocate/ return bounding box with geoid

### DIFF
--- a/client/src/components/NationwideMap.vue
+++ b/client/src/components/NationwideMap.vue
@@ -78,7 +78,14 @@ export default defineComponent({
   },
   methods: {
     zoomToLongLat() {
-      if (this.geoState?.geoids?.lat != null && this.geoState?.geoids.long != null) {
+      if(this.geoState?.geoids?.pwsId?.bounding_box){
+        const {minLat, minLon, maxLat, maxLon} = this.geoState?.geoids?.pwsId?.bounding_box;
+        this.map?.fitBounds([
+          [minLat, minLon],
+          [maxLat, maxLon]
+        ]);
+      }
+      else if (this.geoState?.geoids?.lat != null && this.geoState?.geoids.long != null) {
         const lonLat: LngLatLike = {
           lon: parseInt(this.geoState?.geoids?.long),
           lat: parseInt(this.geoState?.geoids?.lat),

--- a/client/src/components/PredictionPanel.vue
+++ b/client/src/components/PredictionPanel.vue
@@ -35,7 +35,7 @@ import { ScorecardMessages } from '../assets/messages/scorecard_messages';
 import { getParcel, getWaterSystem } from '../model/slices/lead_data_slice';
 import { GeoDataState } from '../model/states/geo_data_state';
 import { LeadDataState } from '../model/states/lead_data_state';
-import { GeoType } from '../model/states/model/geo_data';
+import { BoundedGeoDatum, GeoType } from '../model/states/model/geo_data';
 
 /**
  * Container lead prediction.
@@ -86,7 +86,7 @@ export default defineComponent({
       }
       return null;
     },
-    pwsId(): string | null {
+    pwsId(): BoundedGeoDatum | null {
       // TODO: Handle error state where there is no water system id
       // after the API has returned.
       return this.geoState?.geoids?.pwsId ?? null;
@@ -111,7 +111,7 @@ export default defineComponent({
         dispatch(getParcel(this.geoState.geoids.lat, this.geoState.geoids.long));
 
       } else if (this.geoState?.geoids?.pwsId != null) {
-        dispatch(getWaterSystem(this.geoState.geoids.pwsId));
+        dispatch(getWaterSystem(this.geoState.geoids.pwsId.id));
       }
     },
   },

--- a/client/src/components/ScorecardSummaryPanel.vue
+++ b/client/src/components/ScorecardSummaryPanel.vue
@@ -77,7 +77,7 @@ export default defineComponent({
     // must be fetched.
     'geoState.geoids.zipCode': function() {
       if (this.geoState?.geoids?.zipCode != null) {
-        dispatch(getDemographicData(GeographicLevel.Zipcode, this.geoState.geoids.zipCode));
+        dispatch(getDemographicData(GeographicLevel.Zipcode, this.geoState.geoids.zipCode.id));
       }
     },
   },

--- a/client/src/model/states/model/geo_data.ts
+++ b/client/src/model/states/model/geo_data.ts
@@ -13,12 +13,26 @@ enum GeoType {
  * Model for geo id selection.
  */
 interface GeoData {
-  pwsId?: string;
+  pwsId?: BoundedGeoDatum;
   address?: string;
   geoType?: GeoType;
-  zipCode?: string;
+  zipCode?: BoundedGeoDatum;
   lat?: string;
   long?: string;
 }
 
-export { GeoData, GeoType };
+
+interface BoundingBox {
+  minLat: number;
+  minLon: number;
+  maxLat: number;
+  maxLon: number;
+}
+
+interface BoundedGeoDatum {
+  id: string;
+  bounding_box: BoundingBox;
+}
+
+
+export { GeoData, GeoType, BoundedGeoDatum };


### PR DESCRIPTION
## Description

Addresses: [story](https://tables.area120.google.com/table/bX_kMNBW8LA35n6l5Hz_co/row/9SjAy8XtQi30i0Vy55xOWx)

- Update client to fit map to provided bounding box by default (if available)
- Make geolocate/ return bounding box with geoid
- Prevent geolocate/ from swallowing failed db-query errors

### New

- N/A

### Changed

- Geolocate/ endpoint now returns a richer object including a bounding box instead of a simple string
- If multiple polygons match the provided coords, we sort by ID and return the lowest one. Previously was nondeterministic.
- The client also expects this bounding box to be passed around

### Removed

- N/A

## Testing and Reviewing

- I've only tested the one usecase I understand, which is:
  - Type in an address in the home page
  - Hit 'enter'
  - The map should zoom into the bounding box for the zipcode. The entire zipcode should fit on the map view.
- Note: The zooming (and general interactivity of the map) is pretty slow. I wonder if this is because the polygons we're rendering on it are way too detailed. 
