### PR TITLE
Use env variable for API path.

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -1,32 +1,37 @@
 # Vue.js app
 
 ## Project setup
+
 ```
 npm install
 ```
 
 ### Compiles and hot-reloads for development
+
 ```
 npm run serve
 ```
 
 ### Compiles and minifies for production
+
 ```
 npm run build
 ```
 
 ### Lints and fixes files
+
 ```
 npm run lint
 ```
 
 ### Customize configuration
+
 See [Configuration Reference](https://cli.vuejs.org/config/).
 
-#
-Note: You may have to add a .env file under the client directory with an 
-API key for Mapbox if you haven't already configured that:
+Note: You may have to add a .env file under the client directory with an API key for Mapbox if you
+haven't already configured that:
 
 ```
 VUE_APP_MAP_BOX_API_TOKEN=xxx
+VUE_APP_API_ENDPOINT=https://beekley.leadout-sandbox.blueconduit.com
 ```

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "vue-cli-service serve",
+    "serve": "vue-cli-service serve --mode=development",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint"
   },

--- a/client/src/api/api_client.ts
+++ b/client/src/api/api_client.ts
@@ -8,8 +8,11 @@ import prefixes from '../../../cdk/src/open-data-platform/frontend/url-prefixes'
  */
 class ApiClient {
   // A URL path prefix shared by all API routes.
-  static API_URL = prefixes.api;
+  static API_URL = `${process.env.VUE_APP_API_ENDPOINT}/api`;
 
+  constructor() {
+    console.log('Using API:', ApiClient.API_URL);
+  }
   request = async (endpoint: string, callback: (data: any) => any): Promise<ApiResponse> => {
     axiosRetry(axios, {
       retries: 3,


### PR DESCRIPTION
## Description

https://github.com/BlueConduit/open-data-platform/pull/96 removed a hardcoded path to the API, which local development depended on. This moves it to an env variable.

Everyone should add a new line to their `.env` file that points to the API they want to use. You can check the console to see if it's using the right one. E.g.:

```
VUE_APP_API_ENDPOINT=https://beekley.leadout-sandbox.blueconduit.com
```

### New

- `VUE_APP_API_ENDPOINT` variable for local dev. 

### Changed

- API path.

## Testing and Reviewing

My locally-built client works and makes requests to my sandbox.
