### PR TITLE
Change intersects to contains for more accurate API responses

### DIFF
--- a/api/src/geolocate/get.handler.ts
+++ b/api/src/geolocate/get.handler.ts
@@ -33,7 +33,7 @@ async function getGeoDataForLatLong(
       below.
     Outer Query:
       ST_EXTENT: Aggregates the geometries of all rows returned in the subquery
-      to return their combined bounding box. Sees
+      to return their combined bounding box. See:
       https://postgis.net/docs/manual-1.5/ST_Extent.html
       STRING_AGG: Since ST_EXTENT is an aggregate function (like avg(), max()),
       all other selected rows also need to be aggregated. STRING_AGG just

--- a/api/src/geolocate/get.handler.ts
+++ b/api/src/geolocate/get.handler.ts
@@ -44,7 +44,7 @@ async function getGeoDataForLatLong(
       WITH target_row AS (
         SELECT ${geoid} AS id, geom AS geom
         FROM ${table}
-        WHERE ST_Contains(geom,ST_SetSRID(ST_Point(:long, :lat), 4326))
+        WHERE ST_Contains(geom, ST_SetSRID(ST_Point(:long, :lat), 4326))
           ORDER BY id ASC
           LIMIT 1
       )

--- a/api/src/parcel/get.handler.ts
+++ b/api/src/parcel/get.handler.ts
@@ -13,7 +13,7 @@ const SQL_QUERY = `SELECT address,
                           private_lead_connections_high_estimate,
                           geom
                    FROM parcels
-                   WHERE ST_Contains(geom,ST_SetSRID(ST_Point(:long, :lat), 4326))
+                   WHERE ST_Contains(geom, ST_SetSRID(ST_Point(:long, :lat), 4326))
                    LIMIT 1`;
 
 async function getParcelData(

--- a/api/src/parcel/get.handler.ts
+++ b/api/src/parcel/get.handler.ts
@@ -13,7 +13,7 @@ const SQL_QUERY = `SELECT address,
                           private_lead_connections_high_estimate,
                           geom
                    FROM parcels
-                   WHERE geom && ST_SetSRID(ST_Point(:long, :lat), 4326)
+                   WHERE ST_Contains(geom,ST_SetSRID(ST_Point(:long, :lat), 4326))
                    LIMIT 1`;
 
 async function getParcelData(


### PR DESCRIPTION
Fixes issue where a point was intersecting with multiple states, counties, etc.

Example: 

Request: /scorecard/40.716265,-73.95542 (88 Roebling St, Brooklyn NY 11211)

OLD response body (before deployment):

{"county":{"id":"36047","bounding_box":{"minLat":-74.042412,"minLon":40.5667651450013,"maxLat":-73.833041,"maxLon":40.7394}},"state":{"id":"NJ","bounding_box":{"minLat":-75.559614,"minLon":38.928519,"maxLat":-73.893628,"maxLon":41.357423}},"zip_code":{"id":"11211","bounding_box":{"minLat":-73.964849,"minLon":40.700822,"maxLat":-73.922711,"maxLon":40.725233}},"water_system_pws_id":{"id":"NY0700789","bounding_box":{"minLat":-74.258843,"minLon":40.476578,"maxLat":-73.700169,"maxLon":40.917705}}}



{"state":{"id":"NY","bounding_box":{"minLat":-79.762152,"minLon":40.496103,"maxLat":-71.856214,"maxLon":45.01585}},"zip_code":{"id":"11211","bounding_box":{"minLat":-73.964849,"minLon":40.700822,"maxLat":-73.922711,"maxLon":40.725233}},"county":{"id":"36047","bounding_box":{"minLat":-74.042412,"minLon":40.5667651450013,"maxLat":-73.833041,"maxLon":40.7394}},"water_system_pws_id":{"id":"NY0700789","bounding_box":{"minLat":-74.258843,"minLon":40.476578,"maxLat":-73.700169,"maxLon":40.917705}}}
