### PR TITLE
Fix non-existent spatial indexes by using default index names. 

### DIFF
--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -44,7 +44,7 @@ CREATE TABLE IF NOT EXISTS states
     PRIMARY KEY (census_geo_id)
 );
 
-CREATE INDEX IF NOT EXISTS geom_index ON states USING GIST (geom);
+CREATE INDEX IF NOT EXISTS ON states USING GIST (geom);
 
 -- Counties
 CREATE TABLE IF NOT EXISTS counties
@@ -59,7 +59,7 @@ CREATE TABLE IF NOT EXISTS counties
     geom          geometry(Geometry, 4326),
     PRIMARY KEY (census_geo_id)
 );
-CREATE INDEX IF NOT EXISTS geom_index ON counties USING GIST (geom);
+CREATE INDEX IF NOT EXISTS ON counties USING GIST (geom);
 
 -- Zipcodes
 CREATE TABLE IF NOT EXISTS zipcodes
@@ -72,8 +72,8 @@ CREATE TABLE IF NOT EXISTS zipcodes
     PRIMARY KEY (census_geo_id)
 );
 
-CREATE INDEX IF NOT EXISTS geom_index ON counties USING GIST (geom);
-CREATE UNIQUE INDEX IF NOT EXISTS zipcode_index ON zipcodes (zipcode);
+CREATE INDEX IF NOT EXISTS ON counties USING GIST (geom);
+CREATE UNIQUE INDEX IF NOT EXISTS ON zipcodes (zipcode);
 
 -- Census-block-level data. TODO: consider renaming the table.
 
@@ -91,9 +91,9 @@ CREATE TABLE IF NOT EXISTS demographics
     geom                  GEOMETRY(Geometry, 4326),
     PRIMARY KEY (census_geo_id)
 );
-CREATE INDEX IF NOT EXISTS census_state_geo_id_index ON demographics (state_census_geo_id);
-CREATE INDEX IF NOT EXISTS census_county_geo_id_index ON demographics (county_census_geo_id);
-CREATE INDEX IF NOT EXISTS geom_index ON demographics USING GIST (geom);
+CREATE INDEX IF NOT EXISTS ON demographics (state_census_geo_id);
+CREATE INDEX IF NOT EXISTS ON demographics (county_census_geo_id);
+CREATE INDEX IF NOT EXISTS ON demographics USING GIST (geom);
 
 --- Tables related to U.S. demographic information.
 
@@ -114,8 +114,8 @@ CREATE TABLE IF NOT EXISTS aggregate_us_demographics
     geom                  GEOMETRY(Geometry, 3857),
     PRIMARY KEY (census_geo_id)
 );
-CREATE INDEX IF NOT EXISTS geo_type_index ON aggregate_us_demographics (geo_type);
-CREATE INDEX IF NOT EXISTS geom_index ON aggregate_us_demographics USING GIST (geom);
+CREATE INDEX IF NOT EXISTS ON aggregate_us_demographics (geo_type);
+CREATE INDEX IF NOT EXISTS ON aggregate_us_demographics USING GIST (geom);
 
 -- Demographic aggregation tables.
 
@@ -131,7 +131,7 @@ CREATE TABLE IF NOT EXISTS state_demographics
     geom                  geometry(Geometry, 3857),
     PRIMARY KEY (census_geo_id)
 );
-CREATE INDEX IF NOT EXISTS geom_index ON state_demographics USING GIST (geom);
+CREATE INDEX IF NOT EXISTS ON state_demographics USING GIST (geom);
 
 CREATE TABLE IF NOT EXISTS county_demographics
 (
@@ -145,7 +145,7 @@ CREATE TABLE IF NOT EXISTS county_demographics
     geom                  geometry(Geometry, 3857),
     PRIMARY KEY (census_geo_id)
 );
-CREATE INDEX IF NOT EXISTS geom_index ON county_demographics USING GIST (geom);
+CREATE INDEX IF NOT EXISTS ON county_demographics USING GIST (geom);
 
 -- Water-system-level data
 
@@ -160,8 +160,8 @@ CREATE TABLE IF NOT EXISTS water_systems
     geom                      GEOMETRY(Geometry, 4326),
     PRIMARY KEY (pws_id)
 );
-CREATE INDEX IF NOT EXISTS census_state_geo_id_index ON water_systems (state_census_geo_id);
-CREATE INDEX IF NOT EXISTS geom_index ON water_systems USING GIST (geom);
+CREATE INDEX IF NOT EXISTS ON water_systems (state_census_geo_id);
+CREATE INDEX IF NOT EXISTS ON water_systems USING GIST (geom);
 
 -- EPA violations data
 
@@ -176,7 +176,7 @@ CREATE TABLE IF NOT EXISTS epa_violations
     state_census_geo_id  varchar(255) references states (census_geo_id),
     PRIMARY KEY (violation_id)
 );
-CREATE INDEX IF NOT EXISTS census_state_geo_id_index ON epa_violations (state_census_geo_id);
+CREATE INDEX IF NOT EXISTS ON epa_violations (state_census_geo_id);
 
 -- Violation counts per water system --
 
@@ -212,7 +212,7 @@ CREATE TABLE IF NOT EXISTS parcels
     PRIMARY KEY (address)
 );
 -- Either of these might be used for searching.
-CREATE INDEX IF NOT EXISTS geom_index ON parcels USING GIST (geom);
+CREATE INDEX IF NOT EXISTS ON parcels USING GIST (geom);
 
 CREATE TRIGGER update_last_update_timestamp
     BEFORE UPDATE
@@ -236,7 +236,7 @@ CREATE TABLE IF NOT EXISTS state_lead_connections
     geom                      geometry(Geometry, 3857),
     PRIMARY KEY (census_geo_id)
 );
-CREATE INDEX IF NOT EXISTS geom_index ON state_lead_connections USING GIST (geom);
+CREATE INDEX IF NOT EXISTS ON state_lead_connections USING GIST (geom);
 
 -- EPA Violations aggregation tables.
 
@@ -248,7 +248,7 @@ CREATE TABLE IF NOT EXISTS state_epa_violations
     geom            geometry(Geometry, 3857),
     PRIMARY KEY (census_geo_id)
 );
-CREATE INDEX IF NOT EXISTS geom_index ON state_epa_violations USING GIST (geom);
+CREATE INDEX IF NOT EXISTS ON state_epa_violations USING GIST (geom);
 
 -- Populate pre-computed tables. These are only to be used by the functions
 -- defined below.

--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -72,7 +72,7 @@ CREATE TABLE IF NOT EXISTS zipcodes
     PRIMARY KEY (census_geo_id)
 );
 
-CREATE INDEX IF NOT EXISTS ON counties USING GIST (geom);
+CREATE INDEX IF NOT EXISTS ON zipcodes USING GIST (geom);
 CREATE UNIQUE INDEX IF NOT EXISTS ON zipcodes (zipcode);
 
 -- Census-block-level data. TODO: consider renaming the table.


### PR DESCRIPTION
## Description
- Previously, indexes were named, and many had conflicting names (e.g., 'geom_index').
- In conjunction with `CREATE OR REPLACE` this meant that only the first such index was created, and subsequent `CREATE INDEX` commands were ignored.
- If unspecified, Postgres will choose an index name that is typically a concatenation of the table name and the columns being indexed ( See [reference](https://www.postgresql.org/docs/current/sql-createindex.html#name) ).
  - For example, `CREATE INDEX water_systems_geom_idx ON public.water_systems USING gist (geom)` will yield an index named `water_systems_geom_idx`.
  - I think this should be the preferred option, UNLESS we have a usecase in which we need to reference an index by name, which  I don't think we have.

Addresses: [Fix geom index issue](https://tables.area120.google.com/table/bX_kMNBW8LA35n6l5Hz_co/row/9UhD9iQW1ty6LwZTpEO4UR)

- Drop all attempts to name indexes in schema.sql. Use default names instead.

### New

- None

### Changed

- The following indexes that did not exist should now be created.
```
states USING GIST (geom);
counties USING GIST (geom);
aggregate_us_demographics USING GIST (geom);
state_demographics USING GIST (geom);
county_demographics USING GIST (geom);
water_systems USING GIST (geom);
parcels USING GIST (geom);
state_lead_connections USING GIST (geom);
state_epa_violations USING GIST (geom);
```
- Previously, only `demographics` was indexed. 
- Also, the geometry column on zipcodes was not previously indexed and a duplicate index was created for counties.
- This has been fixed, such that each has one spatial index. 

### Removed

- None

## Testing and Reviewing

- Run schema.sql again
- Run the following query to fetch all indexes:
```sql
SELECT tablename, indexname, indexdef
FROM pg_indexes
ORDER BY tablename, indexname;
```
- Verify that there are 10 GIST indexes.