### PR TITLE
Improve scorecard map load time

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -25,7 +25,7 @@
         "@babel/core": "^7.12.16",
         "@babel/eslint-parser": "^7.12.16",
         "@types/mapbox__mapbox-gl-geocoder": "^4.7.2",
-        "@types/mapbox-gl": "^2.7.4",
+        "@types/mapbox-gl": "^2.7.5",
         "@types/vue-select": "^3.16.0",
         "@typescript-eslint/eslint-plugin": "^5.4.0",
         "@typescript-eslint/parser": "^5.4.0",
@@ -2498,9 +2498,9 @@
       }
     },
     "node_modules/@types/mapbox-gl": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.7.4.tgz",
-      "integrity": "sha512-usTVCWYhmLt+teQ5U3HhSBZIIHFLp6fQXH/1QOnd4xnDtvNTUWo8n6UyRA4kUj84CGpHSBFeF/MNcBdGB1pwog==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.7.5.tgz",
+      "integrity": "sha512-T8gACm3oGKMlBo2l/9vnKEAxgCc0g2mr8g6dI1d3ZO6EzRe7JALBONlWRmc7SOHV79kiarkcdLdDVEnfd+jilA==",
       "dev": true,
       "dependencies": {
         "@types/geojson": "*"
@@ -16489,9 +16489,9 @@
       }
     },
     "@types/mapbox-gl": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.7.4.tgz",
-      "integrity": "sha512-usTVCWYhmLt+teQ5U3HhSBZIIHFLp6fQXH/1QOnd4xnDtvNTUWo8n6UyRA4kUj84CGpHSBFeF/MNcBdGB1pwog==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.7.5.tgz",
+      "integrity": "sha512-T8gACm3oGKMlBo2l/9vnKEAxgCc0g2mr8g6dI1d3ZO6EzRe7JALBONlWRmc7SOHV79kiarkcdLdDVEnfd+jilA==",
       "dev": true,
       "requires": {
         "@types/geojson": "*"

--- a/client/package.json
+++ b/client/package.json
@@ -25,7 +25,7 @@
     "@babel/core": "^7.12.16",
     "@babel/eslint-parser": "^7.12.16",
     "@types/mapbox__mapbox-gl-geocoder": "^4.7.2",
-    "@types/mapbox-gl": "^2.7.4",
+    "@types/mapbox-gl": "^2.7.5",
     "@types/vue-select": "^3.16.0",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",

--- a/client/src/components/NationwideMap.vue
+++ b/client/src/components/NationwideMap.vue
@@ -222,7 +222,16 @@ export default defineComponent({
           }
         });
       }
-      if (this.$props.static) this.map?.dragPan.disable();
+      // Disable all user interaction handlers.
+      if (this.$props.static) {
+        this.map?.boxZoom.disable();
+        this.map?.scrollZoom.disable();
+        this.map?.dragPan.disable();
+        this.map?.dragRotate.disable();
+        this.map?.keyboard.disable();
+        this.map?.doubleClickZoom.disable();
+        this.map?.touchZoomRotate.disable();
+      }
     },
 
     /**
@@ -248,7 +257,7 @@ export default defineComponent({
       );
 
       // Add zoom in / zoom out buttons to map.
-      this.map.addControl(new mapbox.NavigationControl());
+      if (!this.$props.static) this.map.addControl(new mapbox.NavigationControl());
     },
 
     /**

--- a/client/src/components/NationwideMap.vue
+++ b/client/src/components/NationwideMap.vue
@@ -86,22 +86,36 @@ export default defineComponent({
       default: DEFAULT_LNG_LAT,
     },
     height: { type: String, default: '80vh' },
-    pannable: { type: Boolean, default: true },
+    /**
+     * This disables panning and animations.
+     */
+    static: { type: Boolean, default: false },
   },
   methods: {
     zoomToLongLat() {
       if (this.geoState?.geoids?.pwsId?.bounding_box) {
         const { minLat, minLon, maxLat, maxLon } = this.geoState?.geoids?.pwsId?.bounding_box;
-        this.map?.fitBounds([
-          [minLat, minLon],
-          [maxLat, maxLon],
-        ]);
+        this.$props.static
+          ? this.map?.fitBounds(
+              [
+                [minLat, minLon],
+                [maxLat, maxLon],
+              ],
+              // Skip fly animation.
+              { duration: 0 },
+            )
+          : this.map?.fitBounds([
+              [minLat, minLon],
+              [maxLat, maxLon],
+            ]);
       } else if (this.geoState?.geoids?.lat != null && this.geoState?.geoids.long != null) {
         const lonLat: LngLatLike = {
           lon: parseInt(this.geoState?.geoids?.long),
           lat: parseInt(this.geoState?.geoids?.lat),
         };
-        this.map?.flyTo({ center: lonLat, zoom: GeographicLevel.Zipcode });
+        this.$props.static
+          ? this.map?.jumpTo({ center: lonLat, zoom: GeographicLevel.Zipcode })
+          : this.map?.flyTo({ center: lonLat, zoom: GeographicLevel.Zipcode });
       }
     },
     /**
@@ -208,7 +222,7 @@ export default defineComponent({
           }
         });
       }
-      if (!this.$props.pannable) this.map?.dragPan.disable();
+      if (this.$props.static) this.map?.dragPan.disable();
     },
 
     /**

--- a/client/src/components/NationwideMap.vue
+++ b/client/src/components/NationwideMap.vue
@@ -5,8 +5,7 @@
   </div>
 </template>
 
-<script lang='ts'>
-import mapboxgl from 'mapbox-gl';
+<script lang="ts">
 import mapbox, { LngLatLike, MapLayerMouseEvent } from 'mapbox-gl';
 import MapLegend from './MapLegend.vue';
 import MapPopupContent from './MapPopupContent.vue';
@@ -57,8 +56,8 @@ export default defineComponent({
   },
   data() {
     return {
-      map: null as mapboxgl.Map | null,
-      popup: null as mapboxgl.Popup | null,
+      map: null as mapbox.Map | null,
+      popup: null as mapbox.Popup | null,
     };
   },
   computed: {
@@ -87,17 +86,17 @@ export default defineComponent({
       default: DEFAULT_LNG_LAT,
     },
     height: { type: String, default: '80vh' },
+    pannable: { type: Boolean, default: true },
   },
   methods: {
     zoomToLongLat() {
-      if(this.geoState?.geoids?.pwsId?.bounding_box){
-        const {minLat, minLon, maxLat, maxLon} = this.geoState?.geoids?.pwsId?.bounding_box;
+      if (this.geoState?.geoids?.pwsId?.bounding_box) {
+        const { minLat, minLon, maxLat, maxLon } = this.geoState?.geoids?.pwsId?.bounding_box;
         this.map?.fitBounds([
           [minLat, minLon],
-          [maxLat, maxLon]
+          [maxLat, maxLon],
         ]);
-      }
-      else if (this.geoState?.geoids?.lat != null && this.geoState?.geoids.long != null) {
+      } else if (this.geoState?.geoids?.lat != null && this.geoState?.geoids.long != null) {
         const lonLat: LngLatLike = {
           lon: parseInt(this.geoState?.geoids?.long),
           lat: parseInt(this.geoState?.geoids?.lat),
@@ -209,6 +208,7 @@ export default defineComponent({
           }
         });
       }
+      if (!this.$props.pannable) this.map?.dragPan.disable();
     },
 
     /**
@@ -222,7 +222,7 @@ export default defineComponent({
 
       // Add geolocate control to the map.
       this.map.addControl(
-        new mapboxgl.GeolocateControl({
+        new mapbox.GeolocateControl({
           positionOptions: {
             // If enabled, gets the best possible results. Can result in slower response times or
             // increased power consumption so set to false for now.
@@ -234,7 +234,7 @@ export default defineComponent({
       );
 
       // Add zoom in / zoom out buttons to map.
-      this.map.addControl(new mapboxgl.NavigationControl());
+      this.map.addControl(new mapbox.NavigationControl());
     },
 
     /**
@@ -313,22 +313,22 @@ export default defineComponent({
   },
   watch: {
     // Listens to app state to toggle layers.
-    'state.currentDataLayer': function(newDataLayer: DataLayer, oldDataLayer: DataLayer) {
+    'state.currentDataLayer': function (newDataLayer: DataLayer, oldDataLayer: DataLayer) {
       this.updateMapOnDataLayerChange(newDataLayer, oldDataLayer);
     },
     // Listens to query param to toggle layers.
-    routerLayer: function(newLayer: string) {
+    routerLayer: function (newLayer: string) {
       if (newLayer != null) {
         this.setDataLayerVisibility(newLayer, true);
       }
     },
     // Listen for changes to lat/long to update map location.
-    'geoState.geoids': function() {
+    'geoState.geoids': function () {
       const lat = this.geoState?.geoids?.lat;
       const long = this.geoState?.geoids?.long;
 
       if (lat != null && long != null) {
-        const marker = new mapboxgl.Marker({
+        const marker = new mapbox.Marker({
           color: '#0b2553',
         });
 

--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <PredictionPanel />
-    <NationwideMap height='60vh' :pannable='false' />
+    <NationwideMap height='60vh' :static='true' />
     <div class='container-column center-container actions-to-take'>
       <div class='h1-header semi-bold'>
         {{ ScorecardMessages.TAKE_ACTION_HEADER }}

--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -1,30 +1,36 @@
 <template>
   <div>
     <PredictionPanel />
-    <NationwideMap height='60vh' />
+    <NationwideMap height='60vh' :pannable='false' />
     <div class='container-column center-container actions-to-take'>
       <div class='h1-header semi-bold'>
         {{ ScorecardMessages.TAKE_ACTION_HEADER }}
       </div>
-      <ActionSection :header='ScorecardMessages.ADDITIONAL_STEPS_HEADER'
-                     :subheader='ScorecardMessages.ADDITIONAL_STEPS_SUBHEADER'
-                     :buttonText='ScorecardMessages.RESEARCH_WATER_FILTERS'
-                     :style='style'
-                     @onButtonClick='navigateToResourcePage' />
-      <ActionSection :header='ScorecardMessages.SHARE_LEAD_OUT'
-                     :buttonText='ScorecardMessages.COPY_TO_CLIPBOARD'
-                     :style='style'
-                     @onButtonClick='copyToClipboard' />
+      <ActionSection
+        :header='ScorecardMessages.ADDITIONAL_STEPS_HEADER'
+        :subheader='ScorecardMessages.ADDITIONAL_STEPS_SUBHEADER'
+        :buttonText='ScorecardMessages.RESEARCH_WATER_FILTERS'
+        :style='style'
+        @onButtonClick='navigateToResourcePage'
+      />
+      <ActionSection
+        :header='ScorecardMessages.SHARE_LEAD_OUT'
+        :buttonText='ScorecardMessages.COPY_TO_CLIPBOARD'
+        :style='style'
+        @onButtonClick='copyToClipboard'
+      />
     </div>
     <ScorecardSummaryPanel />
-    <ActionSection :header='ScorecardMessages.WANT_TO_KNOW_MORE'
-                   :subheader='ScorecardMessages.EXPLORE_MAP_PAGE_EXPLAINER'
-                   :buttonText='Titles.EXPLORE_NATION_WIDE_MAP'
-                   @onButtonClick='navigateToMapPage' />
+    <ActionSection
+      :header='ScorecardMessages.WANT_TO_KNOW_MORE'
+      :subheader='ScorecardMessages.EXPLORE_MAP_PAGE_EXPLAINER'
+      :buttonText='Titles.EXPLORE_NATION_WIDE_MAP'
+      @onButtonClick='navigateToMapPage'
+    />
   </div>
 </template>
 
-<script lang='ts'>
+<script lang="ts">
 import PredictionPanel from '../components/PredictionPanel.vue';
 import ActionSection from '../components/ActionSection.vue';
 import { defineComponent } from 'vue';
@@ -47,7 +53,7 @@ export default defineComponent({
   },
   data() {
     return {
-      style: { 'color': '#464646' },
+      style: { color: '#464646' },
       ScorecardMessages,
       Titles,
     };
@@ -74,7 +80,7 @@ export default defineComponent({
 
 <style scoped>
 .actions-to-take {
-  background-color: #E1F5FE;
+  background-color: #e1f5fe;
   padding: 20px;
 }
 </style>


### PR DESCRIPTION
## Description

Addresses: [Restrict pan and zoom in scorecard](https://tables.area120.google.com/table/bX_kMNBW8LA35n6l5Hz_co/row/bjMXlJUp0Ze5_iQ-ZA2kwb)

Problem statements:
* Loading the map on a scorecard takes ~5 seconds to render, even when all of the tiles are cached. 
* Panning in the scorecard is slow and stuttery (it uses 100% of my Macbook Pro CPU).

The scorecard view is meant to just show data about the given entity (e.g. parcel, zip), while the map puts that data in context. Users aren't expected to use this view as an entry point for browsing the whole set of nationwide map data.

This PR disables animations and user zoom/pan interaction with the scorecard map. 

TODO: look into simplifying mapbox JS altogether ([context](https://lslr.slack.com/archives/C03D5199TLG/p1660952368390959))

### New

- _Any new things_

### Changed

- _Any changed things_

### Removed

- _Any removed things_

## Testing and Reviewing

TODO: gather data.

See it live in my sandbox: https://beekley.leadout-sandbox.blueconduit.com/scorecard/39.965903,-75.1811125