### PR TITLE
Fix final naming messup

### DIFF
--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -73,7 +73,7 @@ CREATE TABLE IF NOT EXISTS zipcodes
 );
 
 CREATE INDEX IF NOT EXISTS zipcodes_geom_idx ON zipcodes USING GIST (geom);
-CREATE UNIQUE INDEX IF NOT EXISTS ON zipcodes (zipcode);
+CREATE UNIQUE INDEX zipcodes_zipcode_unique_idx IF NOT EXISTS ON zipcodes (zipcode);
 
 -- Census-block-level data. TODO: consider renaming the table.
 


### PR DESCRIPTION
## Description

- CREATE UNIQUE INDEX slipped under the radar last time since its
  a UNIQUE index unlike the others.

Addresses: [Fix DB index naming](https://tables.area120.google.com/table/bX_kMNBW8LA35n6l5Hz_co/row/9UhD9iQW1ty6LwZTpEO4UR)

- Apologies. #114 still incorrectly named the zipcodes index
- This fix is definitely the last one. I checked it works by deploying and watching the logs succeed [here](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Flambda$252Frsrogers-OpenDataPlatform-RootSchemahandler909455B-PWnu0M0oqt3N/log-events/2022$252F08$252F20$252F$255B$2524LATEST$255D113cc4f126d14e4e9cd3bc0ec64f29c8). 

### New

- None

### Changed

- Correctly named the zipcodes index

### Removed

- None

## Testing and Reviewing

- Verify correct deployment via cloud watch logs [here](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Flambda$252Frsrogers-OpenDataPlatform-RootSchemahandler909455B-PWnu0M0oqt3N/log-events/2022$252F08$252F20$252F$255B$2524LATEST$255D113cc4f126d14e4e9cd3bc0ec64f29c8)
