### PR TITLE
Add slack chatbot to notify on alerts

### DIFF
--- a/cdk/src/cdk.ts
+++ b/cdk/src/cdk.ts
@@ -14,4 +14,9 @@ OpenDataPlatform(app, {
   env: { account: '036999211278', region: 'us-east-2' },
   tags: { Project: util.projectName, Environment: util.defaultEnv },
   envType: util.defaultEnv,
+  slackConfig: {
+    slackChannelConfigurationName: 'LeadOut-sandbox',
+    slackWorkspaceId: 'TJTFN34NM',
+    slackChannelId: 'C03V1FX7KC1',
+  },
 });

--- a/cdk/src/open-data-platform/data-plane/data-plane-stack.ts
+++ b/cdk/src/open-data-platform/data-plane/data-plane-stack.ts
@@ -10,6 +10,7 @@ import { DataImportStack } from './data-import/data-import-stack';
 import { DatabaseUserCredentials } from './db-user-credentials/db-user-credentials';
 import { AuroraCapacityUnit } from 'aws-cdk-lib/aws-rds';
 import * as iam from 'aws-cdk-lib/aws-iam';
+import * as sns from 'aws-cdk-lib/aws-sns';
 
 interface DataPlaneProps extends CommonProps {
   vpc: ec2.IVpc;
@@ -20,6 +21,7 @@ export class DataPlaneStack extends Stack {
   readonly databaseName: string;
   readonly tileserverCredentials: DatabaseUserCredentials;
   readonly apiLambdaRole: iam.Role;
+  readonly notificationTopics: sns.ITopic[] = [];
 
   constructor(scope: Construct, id: string, props: DataPlaneProps) {
     super(scope, id, props);
@@ -73,6 +75,7 @@ export class DataPlaneStack extends Stack {
       userCredentials: [this.tileserverCredentials.credentialsSecret],
     });
     rootSchema.node.addDependency(this.tileserverCredentials.credentialsSecret);
+    this.notificationTopics.push(...rootSchema.notificationTopics);
 
     new DataImportStack(this, 'DataImportStack', {
       cluster: this.cluster,

--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -73,7 +73,7 @@ CREATE TABLE IF NOT EXISTS zipcodes
 );
 
 CREATE INDEX IF NOT EXISTS zipcodes_geom_idx ON zipcodes USING GIST (geom);
-CREATE UNIQUE INDEX zipcodes_zipcode_unique_idx IF NOT EXISTS ON zipcodes (zipcode);
+CREATE UNIQUE INDEX IF NOT EXISTS zipcodes_zipcode_unique_idx ON zipcodes (zipcode);
 
 -- Census-block-level data. TODO: consider renaming the table.
 
@@ -214,11 +214,11 @@ CREATE TABLE IF NOT EXISTS parcels
 -- Either of these might be used for searching.
 CREATE INDEX IF NOT EXISTS parcels_geom_idx ON parcels USING GIST (geom);
 
-CREATE TRIGGER update_last_update_timestamp
+SELECT safe_create($$CREATE TRIGGER update_last_update_timestamp
     BEFORE UPDATE
     ON parcels
     FOR EACH ROW
-EXECUTE PROCEDURE update_last_update_timestamp();
+EXECUTE PROCEDURE update_last_update_timestamp()$$);
 
 --- Create pre-computed tables.
 --- These are required to ensure acceptable latency for the tileserver.

--- a/cdk/src/open-data-platform/data-plane/schema/schema.ts
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.ts
@@ -88,19 +88,22 @@ export class Schema extends Construct {
 
     // Monitor errors.
     // TODO: make this general for all lambdas.
-    const topic = new sns.Topic(this, 'SchemaErrorTopic');
+    const topic = new sns.Topic(this, 'ErrorTopic');
     new cloudwatch.MathExpression({
       expression: 'errors / invocations',
+      label: 'Error Fraction',
       usingMetrics: {
         errors: initSchemaFunction.metricErrors(),
         invocations: initSchemaFunction.metricInvocations(),
       },
     })
-      .createAlarm(this, 'SchemaErrorAlarm', {
+      .createAlarm(this, 'ErrorAlarm', {
+        alarmName: 'Schema update lambda error',
         alarmDescription:
           'The schema update lambda has failed. Check the logs for details: https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups$3FlogGroupNameFilter$3Drootschemahandler',
         evaluationPeriods: 1,
         threshold: 1,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
       })
       .addAlarmAction(new actions.SnsAction(topic));
     this.notificationTopics.push(topic);

--- a/cdk/src/open-data-platform/monitoring/monitoring.ts
+++ b/cdk/src/open-data-platform/monitoring/monitoring.ts
@@ -1,0 +1,20 @@
+import { Stack } from 'aws-cdk-lib';
+import * as chatbot from 'aws-cdk-lib/aws-chatbot';
+import { INotificationRuleTarget } from 'aws-cdk-lib/aws-codestarnotifications';
+import { Construct } from 'constructs';
+import { CommonProps } from '../../util';
+
+export class MonitoringStack extends Stack {
+  // This interface can be used by other stacks to send notifications.
+  readonly chatbot: INotificationRuleTarget;
+
+  constructor(scope: Construct, id: string, props: CommonProps) {
+    super(scope, id, props);
+
+    // The chatbot must be manually connected to Slack per AWS account. This can't be done in CDK.
+    this.chatbot = new chatbot.SlackChannelConfiguration(this, 'SlackChannel', {
+      ...props.slackConfig,
+      loggingLevel: chatbot.LoggingLevel.INFO,
+    });
+  }
+}

--- a/cdk/src/open-data-platform/monitoring/monitoring.ts
+++ b/cdk/src/open-data-platform/monitoring/monitoring.ts
@@ -22,6 +22,8 @@ export class MonitoringStack extends Stack {
     });
 
     // Subscribe to each topic from the other stacks.
+    // TODO: make this more independent of other stacks. Right now, updating other stacks sometimes
+    // will fail because this stack depends on the SNS topic resource consumed here.
     props.notificationTopics.forEach((topic) => this.chatbot.addNotificationTopic(topic));
   }
 }

--- a/cdk/src/open-data-platform/monitoring/monitoring.ts
+++ b/cdk/src/open-data-platform/monitoring/monitoring.ts
@@ -1,14 +1,18 @@
 import { Stack } from 'aws-cdk-lib';
 import * as chatbot from 'aws-cdk-lib/aws-chatbot';
-import { INotificationRuleTarget } from 'aws-cdk-lib/aws-codestarnotifications';
+import * as sns from 'aws-cdk-lib/aws-sns';
 import { Construct } from 'constructs';
 import { CommonProps } from '../../util';
 
+interface MonitoringProps extends CommonProps {
+  notificationTopics: sns.ITopic[];
+}
+
 export class MonitoringStack extends Stack {
   // This interface can be used by other stacks to send notifications.
-  readonly chatbot: INotificationRuleTarget;
+  readonly chatbot: chatbot.SlackChannelConfiguration;
 
-  constructor(scope: Construct, id: string, props: CommonProps) {
+  constructor(scope: Construct, id: string, props: MonitoringProps) {
     super(scope, id, props);
 
     // The chatbot must be manually connected to Slack per AWS account. This can't be done in CDK.
@@ -16,5 +20,8 @@ export class MonitoringStack extends Stack {
       ...props.slackConfig,
       loggingLevel: chatbot.LoggingLevel.INFO,
     });
+
+    // Subscribe to each topic from the other stacks.
+    props.notificationTopics.forEach((topic) => this.chatbot.addNotificationTopic(topic));
   }
 }

--- a/cdk/src/open-data-platform/network/network-stack.ts
+++ b/cdk/src/open-data-platform/network/network-stack.ts
@@ -60,6 +60,6 @@ export class NetworkStack extends Stack {
       enableFargateCapacityProviders: true,
     });
 
-    this.dns = new Dns(this, 'DNS', { envType });
+    this.dns = new Dns(this, 'DNS', props);
   }
 }

--- a/cdk/src/open-data-platform/open-data-platform.ts
+++ b/cdk/src/open-data-platform/open-data-platform.ts
@@ -6,6 +6,7 @@ import { DataPlaneStack } from './data-plane/data-plane-stack';
 import { NetworkStack } from './network/network-stack';
 import { FrontendStack } from './frontend/frontend-stack';
 import { AppPlaneStack } from './app-plane/app-plane-stack';
+import { MonitoringStack } from './monitoring/monitoring';
 
 /**
  * Creates the constituent stacks for the platform.
@@ -14,6 +15,9 @@ import { AppPlaneStack } from './app-plane/app-plane-stack';
  */
 export default (scope: Construct, props: CommonProps) => {
   const { envType } = props;
+  const monitoringStack = new MonitoringStack(scope, stackName(StackId.Monitoring, envType), {
+    ...props,
+  });
   const networkStack = new NetworkStack(scope, stackName(StackId.Network, envType), {
     ...props,
   });

--- a/cdk/src/open-data-platform/open-data-platform.ts
+++ b/cdk/src/open-data-platform/open-data-platform.ts
@@ -15,9 +15,6 @@ import { MonitoringStack } from './monitoring/monitoring';
  */
 export default (scope: Construct, props: CommonProps) => {
   const { envType } = props;
-  const monitoringStack = new MonitoringStack(scope, stackName(StackId.Monitoring, envType), {
-    ...props,
-  });
   const networkStack = new NetworkStack(scope, stackName(StackId.Network, envType), {
     ...props,
   });
@@ -36,4 +33,9 @@ export default (scope: Construct, props: CommonProps) => {
     networkStack,
   });
   frontendStack.addDependency(appPlaneStack);
+  const monitoringStack = new MonitoringStack(scope, stackName(StackId.Monitoring, envType), {
+    ...props,
+    notificationTopics: [...dataPlaneStack.notificationTopics],
+  });
+  monitoringStack.addDependency(dataPlaneStack);
 };

--- a/cdk/src/pipeline/pipeline-stack.ts
+++ b/cdk/src/pipeline/pipeline-stack.ts
@@ -62,6 +62,11 @@ export class PipelineStack extends Stack {
         env: { account: '036999211278', region: 'us-east-2' },
         tags: { Project: util.projectName, Environment: util.EnvType.Development },
         envType: util.EnvType.Development,
+        slackConfig: {
+          slackChannelConfigurationName: 'LeadOut-dev',
+          slackWorkspaceId: 'TJTFN34NM',
+          slackChannelId: 'C03UFKFAK9C',
+        },
       }),
     );
   }

--- a/cdk/src/util.ts
+++ b/cdk/src/util.ts
@@ -1,8 +1,10 @@
 import { StackProps } from 'aws-cdk-lib';
+import { SlackChannelConfigurationProps } from 'aws-cdk-lib/aws-chatbot';
 
 // Constants. Define anything that's referenced in multiple places here.
 // Use string enums for easy debugging, since these map to human-readable strings.
 export enum StackId {
+  Monitoring = 'Monitoring',
   Network = 'Network',
   DataPlane = 'DataPlane',
   Frontend = 'Frontend',
@@ -22,6 +24,7 @@ export const baseSubdomain = 'leadout'; // Winner of team vote.
 // https://github.com/BlueConduit/tributary/blob/main/cdk/lib/types.ts
 export interface CommonProps extends StackProps {
   envType: EnvType;
+  slackConfig: SlackChannelConfigurationProps;
 }
 
 export const stackName = (id: StackId, e: EnvType): string => {


### PR DESCRIPTION
## Description

Addresses: [Monitoring](https://tables.area120.google.com/table/bX_kMNBW8LA35n6l5Hz_co/row/bYcpg5d5BPEdlvjUIGh_gZ)

We currently have no monitoring. After each deployment (including to their own sandboxes), devs have to look in the logs in the AWS console to see if it succeeded.

This PR adds a chatbot and one integration to demonstrate how monitoring can work:

1. A stack defines an alert for some metric (e.g. lambda error rate).
2. The monitoring stack subscribes to an SNS topic associated with that alert.
3. The chatbot posts whenever an alert is written to that topic.

However, I don't love this CDK setup since it makes the monitoring stack dependent on all other stacks. I've had trouble updating other stacks with errors like `... cannot be deleted as it is in use by beekley-OpenDataPlatformMonitoring`. I'll look into making it more independent in a future PR.

### New

- Monitoring stack with a slack chatbot.
- Alert for schema update errors.

### Changed

- Fixed a real schema.sql error.

## Testing and Reviewing

My schema was failing to update for [real reasons](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fbeekley-OpenDataPlatformD-RootSchemahandler909455B-xEMDumOKKiDN/log-events/2022$252F08$252F23$252F$255B$2524LATEST$255D6712eedfeb2e4ac09fe42f67adaf927c), and the chatbot [successfully alerted](https://lslr.slack.com/archives/C03V1FX7KC1/p1661269502351689) in [#leadout-sandbox-notifications](https://app.slack.com/client/TJTFN34NM/C03V1FX7KC1).
