### PR TITLE
Give each env its own chatbot config.

### DIFF
--- a/cdk/src/cdk.ts
+++ b/cdk/src/cdk.ts
@@ -15,7 +15,8 @@ OpenDataPlatform(app, {
   tags: { Project: util.projectName, Environment: util.defaultEnv },
   envType: util.defaultEnv,
   slackConfig: {
-    slackChannelConfigurationName: 'LeadOut-sandbox',
+    // Each environment needs its own channel config.
+    slackChannelConfigurationName: util.stackName(util.StackId.Monitoring, util.defaultEnv),
     slackWorkspaceId: 'TJTFN34NM',
     slackChannelId: 'C03V1FX7KC1',
   },


### PR DESCRIPTION
## Description

Addresses: [Monitoring](https://tables.area120.google.com/table/bX_kMNBW8LA35n6l5Hz_co/row/bYcpg5d5BPEdlvjUIGh_gZ)

Sandbox envs were failing to deploy due to [conflicting chatbot config names](https://lslr.slack.com/archives/C03D5199TLG/p1661284694678039). This makes them unique by using `stackName`, which prepends the user's name.