### PR TITLE
Remove problematic stack.

### DIFF
--- a/cdk/src/open-data-platform/open-data-platform.ts
+++ b/cdk/src/open-data-platform/open-data-platform.ts
@@ -6,7 +6,6 @@ import { DataPlaneStack } from './data-plane/data-plane-stack';
 import { NetworkStack } from './network/network-stack';
 import { FrontendStack } from './frontend/frontend-stack';
 import { AppPlaneStack } from './app-plane/app-plane-stack';
-import { MonitoringStack } from './monitoring/monitoring';
 
 /**
  * Creates the constituent stacks for the platform.
@@ -33,9 +32,4 @@ export default (scope: Construct, props: CommonProps) => {
     networkStack,
   });
   frontendStack.addDependency(appPlaneStack);
-  const monitoringStack = new MonitoringStack(scope, stackName(StackId.Monitoring, envType), {
-    ...props,
-    notificationTopics: [...dataPlaneStack.notificationTopics],
-  });
-  monitoringStack.addDependency(dataPlaneStack);
 };


### PR DESCRIPTION
## Description

There can only be one chatbot with the same config, so deployments are [failing](https://lslr.slack.com/archives/C03D5199TLG/p1661353067786629). This removes the monitoring stack to unblock `cdk deploy`.