### PR TITLE
Add monitoring to dev

### DIFF
--- a/cdk/src/monitoring.ts
+++ b/cdk/src/monitoring.ts
@@ -8,7 +8,6 @@ import { stackName, StackId, defaultEnv, projectName } from './util';
 
 const app = new cdk.App();
 
-// TODO: Add this to the deployment pipeline.
 new MonitoringStack(app, StackId.Monitoring, {
   // Development account.
   env: { account: '036999211278', region: 'us-east-2' },
@@ -17,6 +16,7 @@ new MonitoringStack(app, StackId.Monitoring, {
   slackConfig: {
     slackChannelConfigurationName: `${defaultEnv}-${projectName}-channel-config`,
     slackWorkspaceId: 'TJTFN34NM',
+    // #leadout-sandbox-notifications
     slackChannelId: 'C03V1FX7KC1',
   },
 });

--- a/cdk/src/monitoring/monitoring-stack.ts
+++ b/cdk/src/monitoring/monitoring-stack.ts
@@ -4,7 +4,7 @@ import * as sns from 'aws-cdk-lib/aws-sns';
 import { Construct } from 'constructs';
 import { CommonProps, EnvType } from '../util';
 
-interface MonitoringProps extends CommonProps {
+export interface MonitoringProps extends CommonProps {
   slackConfig: chatbot.SlackChannelConfigurationProps;
 }
 

--- a/cdk/src/pipeline/pipeline-stack.ts
+++ b/cdk/src/pipeline/pipeline-stack.ts
@@ -5,7 +5,7 @@ import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as pipelines from 'aws-cdk-lib/pipelines';
 import * as util from '../util';
-import { OpenDataPlatformStage } from './stage';
+import { MonitoringStage, OpenDataPlatformStage } from './stage';
 import { BuildSpec, LinuxBuildImage } from 'aws-cdk-lib/aws-codebuild';
 
 const CODE_REPO = 'BlueConduit/open-data-platform';
@@ -56,6 +56,20 @@ export class PipelineStack extends Stack {
         }),
       },
     });
+
+    pipeline.addStage(
+      new MonitoringStage(this, 'Dev-Monitoring', {
+        env: { account: '036999211278', region: 'us-east-2' },
+        tags: { Project: util.projectName, Environment: util.EnvType.Development },
+        envType: util.EnvType.Development,
+        slackConfig: {
+          slackChannelConfigurationName: `${util.EnvType.Development}-${util.projectName}-channel-config`,
+          slackWorkspaceId: 'TJTFN34NM',
+          // #leadout-dev-notifications
+          slackChannelId: 'C03UFKFAK9C',
+        },
+      }),
+    );
 
     pipeline.addStage(
       new OpenDataPlatformStage(this, 'Dev', {

--- a/cdk/src/pipeline/stage.ts
+++ b/cdk/src/pipeline/stage.ts
@@ -1,5 +1,6 @@
 import { Stage } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
+import { MonitoringProps, MonitoringStack } from '../monitoring/monitoring-stack';
 import OpenDataPlatform from '../open-data-platform/open-data-platform';
 import * as util from '../util';
 
@@ -7,5 +8,12 @@ export class OpenDataPlatformStage extends Stage {
   constructor(scope: Construct, id: string, props: util.CommonProps) {
     super(scope, id);
     OpenDataPlatform(this, props);
+  }
+}
+
+export class MonitoringStage extends Stage {
+  constructor(scope: Construct, id: string, props: MonitoringProps) {
+    super(scope, id);
+    new MonitoringStack(this, util.StackId.Monitoring, props);
   }
 }


### PR DESCRIPTION
## Description

This is a branch off https://github.com/BlueConduit/open-data-platform/pull/125. I'll change the base branch to `main` once that's merged in.

This PR creates a new deployment pipeline stage that turns up a "dev" instance of the monitoring stack, which exposes its own SNS Topic and posts message to the #leadout-dev-notifications channel in slack.

### New

- Monitoring deployment stage.

## Testing and Reviewing

There's not a good way to test this until the pipeline attempts to deploy it.
