### PR TITLE
Client/build info

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
-<!-- Create timestamp at build-time. -->
-<html lang="" data-build-timestamp-utc="<%= new Date().toISOString() %>">
+<html lang="">
   <head>
     <!-- Conditionally include Google Analytics snippet, if targetting production -->
     <% if (process.env.NODE_ENV === 'production') { %>

--- a/client/src/util/build_id.ts
+++ b/client/src/util/build_id.ts
@@ -1,5 +1,3 @@
-const commitUrl = 'https://github.com/BlueConduit/open-data-platform/commit';
-
 /**
  * Logs information about how this client code was built.
  */
@@ -9,8 +7,9 @@ export const logBuildInfo = () => {
   // Log build commit ID.
   // Other variables can be found at: https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
   console.log(process.env);
-  if (process.env.CODEBUILD_RESOLVED_SOURCE_VERSION)
+  if (process.env.CODEBUILD_SOURCE_REPO_URL)
     console.log(
-      `Client built by CodeBuild from Git commit: ${commitUrl}/${process.env.CODEBUILD_RESOLVED_SOURCE_VERSION}`,
+      'Client built by CodeBuild from Git commit:',
+      process.env.CODEBUILD_SOURCE_REPO_URL,
     );
 };

--- a/client/src/util/build_id.ts
+++ b/client/src/util/build_id.ts
@@ -2,8 +2,18 @@
  * Logs information about how this client code was built.
  */
 export const logBuildInfo = () => {
+  // TODO: Record the VUE_APP_BUILD_TIMESTAMP when the client is compiled, if that's even possible.
+  if (process.env.NODE_ENV == 'development')
+    console.log('This is a dev server, so the build timestamp is when `npm run serve` starts.');
+
   // Log build timestamp.
-  console.log('Client built at:', document.documentElement.dataset.buildTimestampUtc);
+  if (process.env.VUE_APP_BUILD_TIMESTAMP) {
+    let buildTimestamp = process.env.VUE_APP_BUILD_TIMESTAMP;
+    const { timeZone } = Intl.DateTimeFormat().resolvedOptions();
+    if (timeZone) buildTimestamp = new Date(buildTimestamp).toLocaleString('en-us', { timeZone });
+    console.log('Client built at:', buildTimestamp);
+  }
+
   // Log build commit ID.
   // Other variables can be found at: https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
   if (process.env.VUE_APP_CODEBUILD_SOURCE_REPO_URL)

--- a/client/src/util/build_id.ts
+++ b/client/src/util/build_id.ts
@@ -1,5 +1,3 @@
-const commitUrl = 'https://github.com/BlueConduit/open-data-platform/commit';
-
 /**
  * Logs information about how this client code was built.
  */
@@ -11,6 +9,7 @@ export const logBuildInfo = () => {
   console.log(process.env);
   if (process.env.CODEBUILD_SOURCE_REPO_URL)
     console.log(
-      'Client built by CodeBuild from Git commit:', ${CODEBUILD_SOURCE_REPO_URL}${process.env.CODEBUILD_RESOLVED_SOURCE_VERSION}`,
+      'Client built by CodeBuild from Git commit:',
+      process.env.CODEBUILD_SOURCE_REPO_URL,
     );
 };

--- a/client/src/util/build_id.ts
+++ b/client/src/util/build_id.ts
@@ -15,10 +15,15 @@ export const logBuildInfo = () => {
   }
 
   // Log build commit ID.
-  // Other variables can be found at: https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
   if (process.env.VUE_APP_CODEBUILD_SOURCE_REPO_URL)
     console.log(
       'Client built by CodeBuild from git commit:',
       process.env.VUE_APP_CODEBUILD_SOURCE_REPO_URL,
+    );
+  // Or manually construct the URL if not present.
+  else if (process.env.VUE_APP_CODEBUILD_RESOLVED_SOURCE_VERSION)
+    console.log(
+      'Client built by CodeBuild from git commit:',
+      `https://github.com/BlueConduit/open-data-platform/commit/${process.env.VUE_APP_CODEBUILD_RESOLVED_SOURCE_VERSION}`,
     );
 };

--- a/client/src/util/build_id.ts
+++ b/client/src/util/build_id.ts
@@ -6,10 +6,9 @@ export const logBuildInfo = () => {
   console.log('Client built at:', document.documentElement.dataset.buildTimestampUtc);
   // Log build commit ID.
   // Other variables can be found at: https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
-  console.log(process.env);
-  if (process.env.CODEBUILD_SOURCE_REPO_URL)
+  if (process.env.VUE_APP_CODEBUILD_SOURCE_REPO_URL)
     console.log(
-      'Client built by CodeBuild from Git commit:',
-      process.env.CODEBUILD_SOURCE_REPO_URL,
+      'Client built by CodeBuild from git commit:',
+      process.env.VUE_APP_CODEBUILD_SOURCE_REPO_URL,
     );
 };

--- a/client/vue.config.js
+++ b/client/vue.config.js
@@ -3,5 +3,6 @@ module.exports = defineConfig({
   transpileDependencies: true,
 });
 
-// Make CodeBuild env vars available to the Vue client.
+// Make build env vars available to the Vue client.
+process.env.VUE_APP_BUILD_TIMESTAMP = new Date().toISOString();
 process.env.VUE_APP_CODEBUILD_SOURCE_REPO_URL = process.env.CODEBUILD_SOURCE_REPO_URL;

--- a/client/vue.config.js
+++ b/client/vue.config.js
@@ -4,5 +4,10 @@ module.exports = defineConfig({
 });
 
 // Make build env vars available to the Vue client.
+// Other variables can be found at: https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
 process.env.VUE_APP_BUILD_TIMESTAMP = new Date().toISOString();
-process.env.VUE_APP_CODEBUILD_SOURCE_REPO_URL = process.env.CODEBUILD_SOURCE_REPO_URL;
+if (process.env.CODEBUILD_SOURCE_REPO_URL)
+  process.env.VUE_APP_CODEBUILD_SOURCE_REPO_URL = process.env.CODEBUILD_SOURCE_REPO_URL;
+if (process.env.CODEBUILD_RESOLVED_SOURCE_VERSION)
+  process.env.VUE_APP_CODEBUILD_RESOLVED_SOURCE_VERSION =
+    process.env.CODEBUILD_RESOLVED_SOURCE_VERSION;

--- a/client/vue.config.js
+++ b/client/vue.config.js
@@ -1,4 +1,7 @@
-const { defineConfig } = require('@vue/cli-service')
+const { defineConfig } = require('@vue/cli-service');
 module.exports = defineConfig({
-  transpileDependencies: true
-})
+  transpileDependencies: true,
+});
+
+// Make CodeBuild env vars available to the Vue client.
+process.env.VUE_APP_CODEBUILD_SOURCE_REPO_URL = process.env.CODEBUILD_SOURCE_REPO_URL;


### PR DESCRIPTION
## Description

https://github.com/BlueConduit/open-data-platform/pull/131 Added some build info logs. But it didn't display the commit URL. According to [the docs](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html):

> If a build originates from CodePipeline, this environment variable may be empty.

And it was empty. Specifically, it was `undefined`, which I think was cast to a string literal when used as an env var.

### Changed

- Use a different env var if the URL doesn't exist.

## Testing and Reviewing

Unfortunately, we can't test until this hits dev.
