### PR TITLE
Lslr section

### DIFF
--- a/api/src/parcel/get.handler.ts
+++ b/api/src/parcel/get.handler.ts
@@ -4,7 +4,7 @@ import { RDSDataService } from 'aws-sdk';
 import { ExecuteStatementRequest, SqlParametersList } from 'aws-sdk/clients/rdsdataservice';
 import { CORS_HEADERS } from '../util';
 
-const COLUMNS_SELECTED = 6;
+const COLUMNS_SELECTED = 7;
 const SCHEMA = 'public';
 const SQL_QUERY = `SELECT address,
                           city,

--- a/api/src/parcel/get.handler.ts
+++ b/api/src/parcel/get.handler.ts
@@ -7,6 +7,7 @@ import { CORS_HEADERS } from '../util';
 const COLUMNS_SELECTED = 6;
 const SCHEMA = 'public';
 const SQL_QUERY = `SELECT address,
+                          city,
                           public_lead_connections_low_estimate,
                           public_lead_connections_high_estimate,
                           private_lead_connections_low_estimate,
@@ -37,11 +38,12 @@ async function getParcelData(
     }
     body = {
       address: record[0].stringValue,
-      public_lead_low_prediction: record[1].doubleValue,
-      public_lead_high_prediction: record[2].doubleValue,
-      private_lead_low_prediction: record[3].doubleValue,
-      private_lead_high_prediction: record[4].doubleValue,
-      geom: record[5].stringValue,
+      city: record[1].stringValue,
+      public_lead_low_prediction: record[2].doubleValue,
+      public_lead_high_prediction: record[3].doubleValue,
+      private_lead_low_prediction: record[4].doubleValue,
+      private_lead_high_prediction: record[5].doubleValue,
+      geom: record[6].stringValue,
     };
   }
   return body;
@@ -102,6 +104,7 @@ export const handler = async (event: {
  */
 interface ParcelApiResponse {
   address?: string;
+  city?: string;
   public_lead_low_prediction?: number;
   public_lead_high_prediction?: number;
   private_lead_low_prediction?: number;

--- a/cdk/src/open-data-platform/data-plane/data-import/data-import-stack.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/data-import-stack.ts
@@ -46,7 +46,7 @@ export class DataImportStack extends Construct {
 
     const { cluster, credentialsSecret } = props;
 
-    const s3BucketWithDataFiles = new s3.Bucket(this, 'open_data_platform_static_files');
+    const s3BucketWithDataFiles = new s3.Bucket(this, `${id}-open_data_platform_static_files`);
 
     // Allow reads to all S3 buckets in account.
     const s3GetObjectPolicy = new iam.PolicyStatement({

--- a/cdk/src/open-data-platform/data-plane/data-import/write-parcels-data.handler.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/write-parcels-data.handler.ts
@@ -64,7 +64,7 @@ function getTableRowFromRow(row: any): SqlParametersList {
   return (
     new ParcelsTableRowBuilder()
       .address(properties.address)
-      .city(properties.city ?? '')
+      .city('toledo') // TODO: change this if we load other city parcel data.
       // TODO: Change to real properties once we have them.
       .publicLeadLowPrediction(getValueOrDefault(properties.y_score_pub))
       .publicLeadHighPrediction(getValueOrDefault(properties.y_score_pub))

--- a/cdk/src/open-data-platform/data-plane/data-import/write-parcels-data.handler.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/write-parcels-data.handler.ts
@@ -4,6 +4,7 @@ import { ParcelsTableRowBuilder } from '../model/parcels-table';
 import { geoJsonHandlerFactory } from './handler-factory';
 
 const SCHEMA = 'schema';
+const CITY = 'toledo';
 
 // This file contains < 145k rows
 const s3Params = {
@@ -11,7 +12,7 @@ const s3Params = {
   // The geometries have been simplified. This file also only includes
   // the rows we currently write to the db to avoid large javascript
   // objects from being created on streamArray().
-  Key: 'parcels/toledo_parcel_preds.geojson',
+  Key: `parcels/${CITY}_parcel_preds.geojson`,
 };
 
 /**
@@ -64,7 +65,7 @@ function getTableRowFromRow(row: any): SqlParametersList {
   return (
     new ParcelsTableRowBuilder()
       .address(properties.address)
-      .city('toledo') // TODO: change this if we load other city parcel data.
+      .city(CITY)
       // TODO: Change to real properties once we have them.
       .publicLeadLowPrediction(getValueOrDefault(properties.y_score_pub))
       .publicLeadHighPrediction(getValueOrDefault(properties.y_score_pub))

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -20,7 +20,7 @@ import { leadAndCopperViolationsByCountyDataLayer } from './data_layer_configs/l
 import { leadServiceLinesByParcelLayer } from './data_layer_configs/lead_service_lines_by_parcel_config';
 import { queryLatLong } from './model/slices/geo_data_slice';
 import { dispatch } from './model/store';
-import { LAT_LONG_PARAM } from './router';
+import { GEOTYPE_PARAM, LAT_LONG_PARAM } from './router';
 import { GeoType } from './model/states/model/geo_data';
 import PageFooter from './components/PageFooter.vue';
 
@@ -56,14 +56,16 @@ export default defineComponent({
     // Current route location. See https://router.vuejs.org/api/#component-injections.
     $route(to: RouteLocation) {
       const latLongValue: string = to.params[LAT_LONG_PARAM] as string;
+      const geoTypeValue: string = to.params[GEOTYPE_PARAM] as string;
 
       if (latLongValue?.length > 0) {
         const latLong = latLongValue.split(',');
         const lat = latLong[0];
         const long = latLong[1];
+        const geoType = Object.values(GeoType).find((geo) => geo == geoTypeValue) as GeoType;
 
         // TODO: Pass real geo type.
-        dispatch(queryLatLong(lat, long, GeoType.postcode));
+        dispatch(queryLatLong(lat, long, geoType));
       }
 
       // TODO: consider adding a string that says this is a non-prod environment, so devs can see

--- a/client/src/api/api_client.ts
+++ b/client/src/api/api_client.ts
@@ -94,6 +94,7 @@ class ApiClient {
     return this.request(`${ApiClient.API_URL}/parcel/${lat},${long}`, (data) => {
       return {
         address: data?.data?.address,
+        city: data?.data?.city,
         publicLeadLowPrediction: data?.data?.public_lead_low_prediction,
         publicLeadHighPrediction: data?.data?.public_lead_high_prediction,
         privateLeadLowPrediction: data?.data?.private_lead_low_prediction,

--- a/client/src/assets/messages/scorecard_messages.ts
+++ b/client/src/assets/messages/scorecard_messages.ts
@@ -38,6 +38,10 @@ export class ScorecardMessages {
     'collected from your utility and other sources';
   static LEARN_MORE = 'Learn more';
   static LOWER_INCOME = 'Lower income';
+  static LSLR_HEADER = 'Lead Service Line Replacement Pilot';
+  static LSLR_SUBHEADER = 'Learn more about lead service replacements happening in your area ' + 
+  'and your eligibility status.';
+  static LSLR_CTA_TEXT = 'Go to city of Richmond website';
   static RESEARCH_WATER_FILTERS = 'Research water filters';
   static SCORECARD_SUMMARY_PANEL_SUBHEADER =
     'In addition to information from your water system, your score is also based on ' +

--- a/client/src/assets/messages/scorecard_messages.ts
+++ b/client/src/assets/messages/scorecard_messages.ts
@@ -41,7 +41,6 @@ export class ScorecardMessages {
   static LSLR_HEADER = 'Lead Service Line Replacement Pilot';
   static LSLR_SUBHEADER = 'Learn more about lead service replacements happening in your area ' + 
   'and your eligibility status.';
-  static LSLR_CTA_TEXT = 'Go to city of Richmond website';
   static RESEARCH_WATER_FILTERS = 'Research water filters';
   static SCORECARD_SUMMARY_PANEL_SUBHEADER =
     'In addition to information from your water system, your score is also based on ' +

--- a/client/src/components/LslrSection.vue
+++ b/client/src/components/LslrSection.vue
@@ -5,7 +5,7 @@
       <div class='h2-header-large'>{{ messages.LSLR_SUBHEADER }}</div>
       <button class='gold-button'>
         <a :href='cityLink' target='_blank' rel='noopener noreferrer'>
-        {{ messages.LSLR_CTA_TEXT }}
+          {{ messages.LSLR_CTA_TEXT }}
         </a>
       </button>
     </div>

--- a/client/src/components/LslrSection.vue
+++ b/client/src/components/LslrSection.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class='section'>
+    <div class='header-section'>
+      <div class='h1-header-large'>{{ messages.LSLR_HEADER }}</div>
+      <div class='h2-header-large'>{{ messages.LSLR_SUBHEADER }}</div>
+      <button class='gold-button'>{{ messages.LSLR_CTA_TEXT }}</button>
+    </div>
+  </div>
+</template>
+
+<script lang='ts'>
+import { defineComponent } from 'vue';
+import { ScorecardMessages as messages } from '@/assets/messages/scorecard_messages';
+
+/**
+ * Lslr section component.
+ */
+export default defineComponent({
+  name: 'LslrSection',
+  data() {
+    return {
+      messages,
+    };
+  },
+});
+</script>
+
+<style scoped lang='scss'>
+@import '../assets/styles/global.scss';
+@import '@blueconduit/copper/scss/01_settings/design-tokens';
+
+.section {
+    background-color: $white;
+    color: $warm-grey-800;
+}
+</style>

--- a/client/src/components/LslrSection.vue
+++ b/client/src/components/LslrSection.vue
@@ -22,7 +22,9 @@ export const LSLR_CITY_LINKS: Map<City, string> = new Map<City, string>([
 ]);
 
 /**
- * Lslr section component.
+ * Lead service line replacement (LSLR) section component.
+ *
+ * Contains city-specific LSLR program information.
  */
 export default defineComponent({
   name: 'LslrSection',

--- a/client/src/components/LslrSection.vue
+++ b/client/src/components/LslrSection.vue
@@ -17,9 +17,9 @@ import { defineComponent, PropType } from 'vue';
 import { ScorecardMessages as messages } from '@/assets/messages/scorecard_messages';
 import { City } from '@/model/states/model/geo_data';
 
-export const LSLR_CITY_LINKS = {
-    toledo : 'https://toledo.oh.gov/residents/water/lead-service-lines/customer-side',
-}
+export const LSLR_CITY_LINKS: Map<City, string> = new Map<City, string>([
+  [City.toledo, 'https://toledo.oh.gov/residents/water/lead-service-lines/customer-side'],
+]);
 
 /**
  * Lslr section component.
@@ -28,13 +28,13 @@ export default defineComponent({
   name: 'LslrSection',
   props: {
     city: {
-      type: Object as PropType<City>,
+      type: String as PropType<City>,
       required: true,
-    }
+    },
   },
   computed: {
     cityLink: function(): string {
-      return LSLR_CITY_LINKS[this.city];
+      return LSLR_CITY_LINKS.get(this.city) ?? '';
     },
   },
   data() {
@@ -55,7 +55,7 @@ a {
 }
 
 .section {
-    background-color: $white;
-    color: $warm-grey-800;
+  background-color: $white;
+  color: $warm-grey-800;
 }
 </style>

--- a/client/src/components/LslrSection.vue
+++ b/client/src/components/LslrSection.vue
@@ -5,7 +5,7 @@
       <div class='h2-header-large'>{{ messages.LSLR_SUBHEADER }}</div>
       <button class='gold-button'>
         <a :href='cityLink' target='_blank' rel='noopener noreferrer'>
-          {{ messages.LSLR_CTA_TEXT }}
+          Go to city of {{ city }} website
         </a>
       </button>
     </div>
@@ -33,9 +33,9 @@ export default defineComponent({
     }
   },
   computed: {
-    cityLink(): string {
+    cityLink: function(): string {
       return LSLR_CITY_LINKS[this.city];
-    }
+    },
   },
   data() {
     return {

--- a/client/src/components/LslrSection.vue
+++ b/client/src/components/LslrSection.vue
@@ -9,14 +9,24 @@
 </template>
 
 <script lang='ts'>
-import { defineComponent } from 'vue';
+import { defineComponent, PropType } from 'vue';
 import { ScorecardMessages as messages } from '@/assets/messages/scorecard_messages';
+import { City } from '@/model/states/model/geo_data';
+import { GeoDataState } from '@/model/states/geo_data_state';
+import { useSelector } from '@/model/store';
+
+const LSLR_CITY_LINKS = {
+    toledo : 'https://toledo.oh.gov/residents/water/lead-service-lines/customer-side',
+}
 
 /**
  * Lslr section component.
  */
 export default defineComponent({
   name: 'LslrSection',
+  props: {
+    city: Object as PropType<City>,
+  },
   data() {
     return {
       messages,

--- a/client/src/components/LslrSection.vue
+++ b/client/src/components/LslrSection.vue
@@ -3,7 +3,11 @@
     <div class='header-section'>
       <div class='h1-header-large'>{{ messages.LSLR_HEADER }}</div>
       <div class='h2-header-large'>{{ messages.LSLR_SUBHEADER }}</div>
-      <button class='gold-button'>{{ messages.LSLR_CTA_TEXT }}</button>
+      <button class='gold-button'>
+        <a :href='cityLink' target='_blank' rel='noopener noreferrer'>
+        {{ messages.LSLR_CTA_TEXT }}
+        </a>
+      </button>
     </div>
   </div>
 </template>
@@ -12,10 +16,8 @@
 import { defineComponent, PropType } from 'vue';
 import { ScorecardMessages as messages } from '@/assets/messages/scorecard_messages';
 import { City } from '@/model/states/model/geo_data';
-import { GeoDataState } from '@/model/states/geo_data_state';
-import { useSelector } from '@/model/store';
 
-const LSLR_CITY_LINKS = {
+export const LSLR_CITY_LINKS = {
     toledo : 'https://toledo.oh.gov/residents/water/lead-service-lines/customer-side',
 }
 
@@ -25,7 +27,15 @@ const LSLR_CITY_LINKS = {
 export default defineComponent({
   name: 'LslrSection',
   props: {
-    city: Object as PropType<City>,
+    city: {
+      type: Object as PropType<City>,
+      required: true,
+    }
+  },
+  computed: {
+    cityLink(): string {
+      return LSLR_CITY_LINKS[this.city];
+    }
   },
   data() {
     return {
@@ -38,6 +48,11 @@ export default defineComponent({
 <style scoped lang='scss'>
 @import '../assets/styles/global.scss';
 @import '@blueconduit/copper/scss/01_settings/design-tokens';
+
+a {
+  text-decoration: none;
+  color: $text-dark;
+}
 
 .section {
     background-color: $white;

--- a/client/src/components/landing_page/ScorecardSearch.vue
+++ b/client/src/components/landing_page/ScorecardSearch.vue
@@ -36,6 +36,7 @@ export default defineComponent({
     return {
       lat: 0,
       long: 0,
+      geoType: GeoType.unknown,
       acceptedTypes: [GeoType.address, GeoType.postcode],
     };
   },
@@ -45,12 +46,13 @@ export default defineComponent({
     },
   },
   methods: {
-    onGeocodeResults(lat: number, long: number) {
+    onGeocodeResults(lat: number, long: number, geoType: GeoType) {
       this.lat = lat;
       this.long = long;
+      this.geoType = geoType;
     },
     onSearch() {
-      this.$router.push(`${SCORECARD_BASE}/${this.lat},${this.long}`);
+      this.$router.push(`${SCORECARD_BASE}/${this.geoType}/${this.lat},${this.long}`);
     },
   },
 });

--- a/client/src/model/states/model/geo_data.ts
+++ b/client/src/model/states/model/geo_data.ts
@@ -18,6 +18,15 @@ enum GeoType {
 }
 
 /**
+ * Represents cities which we have parcel data for. 
+ * 
+ * Used to display city-specific information.
+ */
+enum City {
+  toledo = 'toledo',
+}
+
+/**
  * Model for geo id selection.
  */
 interface GeoData {
@@ -27,6 +36,7 @@ interface GeoData {
   zipCode?: BoundedGeoDatum;
   lat?: string;
   long?: string;
+  city?: City;
 }
 
 
@@ -43,4 +53,4 @@ interface BoundedGeoDatum {
 }
 
 
-export { GeoData, GeoType, BoundedGeoDatum };
+export { City, GeoData, GeoType, BoundedGeoDatum };

--- a/client/src/model/states/model/geo_data.ts
+++ b/client/src/model/states/model/geo_data.ts
@@ -18,12 +18,13 @@ enum GeoType {
 }
 
 /**
- * Represents cities which we have parcel data for. 
- * 
+ * Represents cities which we have parcel data for.
+ *
  * Used to display city-specific information.
  */
 enum City {
   toledo = 'toledo',
+  unknown = 'unknown',
 }
 
 /**
@@ -36,9 +37,7 @@ interface GeoData {
   zipCode?: BoundedGeoDatum;
   lat?: string;
   long?: string;
-  city?: City;
 }
-
 
 interface BoundingBox {
   minLat: number;
@@ -51,6 +50,5 @@ interface BoundedGeoDatum {
   id: string;
   bounding_box: BoundingBox;
 }
-
 
 export { City, GeoData, GeoType, BoundedGeoDatum };

--- a/client/src/model/states/model/lead_data.ts
+++ b/client/src/model/states/model/lead_data.ts
@@ -1,8 +1,11 @@
 /**
  * Information about lead at geo-granularity.
  */
+import { City } from '@/model/states/model/geo_data';
+
 export interface LeadData {
   address?: string;
+  city?: City;
   pwsId?: string;
   leadServiceLines?: number;
   serviceLines?: number;

--- a/client/src/router.ts
+++ b/client/src/router.ts
@@ -7,10 +7,11 @@ import NationwideMapView from '@/views/NationwideMapView.vue';
 import AboutUsView from '@/views/AboutUsView.vue';
 
 export const LAT_LONG_PARAM = 'latlong';
+export const GEOTYPE_PARAM = 'geotype';
 
 const HOME_ROUTE = '/';
 const SCORECARD_BASE = `/scorecard`;
-const SCORECARD_ROUTE = `${SCORECARD_BASE}/:${LAT_LONG_PARAM}?`;
+const SCORECARD_ROUTE = `${SCORECARD_BASE}/:${GEOTYPE_PARAM}/:${LAT_LONG_PARAM}?`;
 const MAP_ROUTE_BASE = `/map`;
 const MAP_ROUTE = `${MAP_ROUTE_BASE}/:${LAT_LONG_PARAM}?`;
 const ABOUT_ROUTE = '/about';

--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -25,7 +25,9 @@
       :buttonText='Titles.EXPLORE_NATION_WIDE_MAP'
       @onButtonClick='navigateToMapPage'
     />
-    <LslrSection v-if='showLslr' :city='geoState?.geoids?.city'/>
+    <!-- TODO uncomment below and remove hard coded city after testing. -->
+    <!-- <LslrSection v-if='showLslr' :city='geoState?.geoids?.city'/> -->
+      <LslrSection v-if='true' city='toledo'/>
   </div>
 </template>
 
@@ -39,6 +41,7 @@ import { ScorecardMessages } from '../assets/messages/scorecard_messages';
 import { Titles } from '../assets/messages/common';
 import NationwideMap from '../components/NationwideMap.vue';
 import LslrSection from '@/components/LslrSection.vue';
+import LSLR_CITY_LINKS from '@/components/LslrSection.vue';
 import { GeoDataState } from '@/model/states/geo_data_state';
 import { useSelector } from '@/model/store';
 
@@ -86,7 +89,8 @@ export default defineComponent({
   },
   watch: {
     'geoState.geoids': function() {
-        this.showLslr = this.geoState?.geoids?.city == null;
+        const city = this.geoState?.geoids?.city;
+        this.showLslr = city != null && LSLR_CITY_LINKS[city] != null;
     },
   },
 });

--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -25,8 +25,7 @@
       :buttonText='Titles.EXPLORE_NATION_WIDE_MAP'
       @onButtonClick='navigateToMapPage'
     />
-    <LslrSection />
-    <!-- TODO add lslr section here -->
+    <LslrSection v-if='showLslr' :city='geoState?.geoids?.city'/>
   </div>
 </template>
 
@@ -40,6 +39,8 @@ import { ScorecardMessages } from '../assets/messages/scorecard_messages';
 import { Titles } from '../assets/messages/common';
 import NationwideMap from '../components/NationwideMap.vue';
 import LslrSection from '@/components/LslrSection.vue';
+import { GeoDataState } from '@/model/states/geo_data_state';
+import { useSelector } from '@/model/store';
 
 /**
  * Container for SearchBar and MapContainer.
@@ -52,11 +53,19 @@ export default defineComponent({
     PredictionPanel,
     ScorecardSummaryPanel,
     LslrSection
-},
+  },
+  setup () {
+    const geoState = useSelector((state) => state.geos) as GeoDataState;
+
+    return {
+      geoState,
+    }
+  },
   data() {
     return {
       ScorecardMessages,
       Titles,
+      showLslr: false,
     };
   },
   methods: {
@@ -73,6 +82,11 @@ export default defineComponent({
       router.push({
         path: '/map',
       });
+    },
+  },
+  watch: {
+    'geoState.geoids': function() {
+        this.showLslr = this.geoState?.geoids?.city == null;
     },
   },
 });

--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -7,12 +7,14 @@
         {{ ScorecardMessages.TAKE_ACTION_HEADER }}
       </div>
       <ActionSection
+        class='section'
         :header='ScorecardMessages.ADDITIONAL_STEPS_HEADER'
         :subheader='ScorecardMessages.ADDITIONAL_STEPS_SUBHEADER'
         :buttonText='ScorecardMessages.RESEARCH_WATER_FILTERS'
         @onButtonClick='navigateToResourcePage'
       />
       <ActionSection
+        class='section'
         :header='ScorecardMessages.SHARE_LEAD_OUT'
         :buttonText='ScorecardMessages.COPY_TO_CLIPBOARD'
         @onButtonClick='copyToClipboard'
@@ -20,6 +22,7 @@
     </div>
     <ScorecardSummaryPanel />
     <ActionSection
+      class='nav-to-map section'
       :header='ScorecardMessages.WANT_TO_KNOW_MORE'
       :subheader='ScorecardMessages.EXPLORE_MAP_PAGE_EXPLAINER'
       :buttonText='Titles.EXPLORE_NATION_WIDE_MAP'
@@ -87,7 +90,7 @@ export default defineComponent({
     },
   },
   watch: {
-    leadDataState: function() {
+    'leadDataState.data.city': function() {
       const city = this.leadDataState?.data?.city ?? City.unknown;
       this.showLslr = city != null && LSLR_CITY_LINKS.get(city) != null;
     },
@@ -101,5 +104,9 @@ export default defineComponent({
 
 .actions-to-take {
   padding: $spacing-lg;
+}
+
+.nav-to-map {
+  background-color: $light-blue-50;
 }
 </style>

--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -25,6 +25,8 @@
       :buttonText='Titles.EXPLORE_NATION_WIDE_MAP'
       @onButtonClick='navigateToMapPage'
     />
+    <LslrSection />
+    <!-- TODO add lslr section here -->
   </div>
 </template>
 
@@ -37,6 +39,7 @@ import ScorecardSummaryPanel from '../components/ScorecardSummaryPanel.vue';
 import { ScorecardMessages } from '../assets/messages/scorecard_messages';
 import { Titles } from '../assets/messages/common';
 import NationwideMap from '../components/NationwideMap.vue';
+import LslrSection from '@/components/LslrSection.vue';
 
 /**
  * Container for SearchBar and MapContainer.
@@ -48,7 +51,8 @@ export default defineComponent({
     NationwideMap,
     PredictionPanel,
     ScorecardSummaryPanel,
-  },
+    LslrSection
+},
   data() {
     return {
       ScorecardMessages,

--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -26,8 +26,8 @@
       @onButtonClick='navigateToMapPage'
     />
     <!-- TODO uncomment below and remove hard coded city after testing. -->
-    <!-- <LslrSection v-if='showLslr' :city='geoState?.geoids?.city'/> -->
-      <LslrSection v-if='true' city='toledo'/>
+    <LslrSection v-if='showLslr' :city='geoState?.geoids?.city'/>
+      <!-- <LslrSection v-if='true' city='toledo'/> -->
   </div>
 </template>
 

--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -25,13 +25,11 @@
       :buttonText='Titles.EXPLORE_NATION_WIDE_MAP'
       @onButtonClick='navigateToMapPage'
     />
-    <!-- TODO uncomment below and remove hard coded city after testing. -->
-    <LslrSection v-if='showLslr' :city='geoState?.geoids?.city'/>
-      <!-- <LslrSection v-if='true' city='toledo'/> -->
+    <LslrSection v-if='showLslr' :city='leadDataState?.data?.city' />
   </div>
 </template>
 
-<script lang="ts">
+<script lang='ts'>
 import PredictionPanel from '../components/PredictionPanel.vue';
 import ActionSection from '../components/ActionSection.vue';
 import { defineComponent } from 'vue';
@@ -41,9 +39,10 @@ import { ScorecardMessages } from '../assets/messages/scorecard_messages';
 import { Titles } from '../assets/messages/common';
 import NationwideMap from '../components/NationwideMap.vue';
 import LslrSection from '@/components/LslrSection.vue';
-import LSLR_CITY_LINKS from '@/components/LslrSection.vue';
-import { GeoDataState } from '@/model/states/geo_data_state';
+import { LSLR_CITY_LINKS } from '@/components/LslrSection.vue';
 import { useSelector } from '@/model/store';
+import { LeadDataState } from '../model/states/lead_data_state';
+import { City } from '../model/states/model/geo_data';
 
 /**
  * Container for SearchBar and MapContainer.
@@ -55,14 +54,14 @@ export default defineComponent({
     NationwideMap,
     PredictionPanel,
     ScorecardSummaryPanel,
-    LslrSection
+    LslrSection,
   },
-  setup () {
-    const geoState = useSelector((state) => state.geos) as GeoDataState;
+  setup() {
+    const leadDataState = useSelector((state) => state.leadData) as LeadDataState;
 
     return {
-      geoState,
-    }
+      leadDataState,
+    };
   },
   data() {
     return {
@@ -88,15 +87,15 @@ export default defineComponent({
     },
   },
   watch: {
-    'geoState.geoids': function() {
-        const city = this.geoState?.geoids?.city;
-        this.showLslr = city != null && LSLR_CITY_LINKS[city] != null;
+    leadDataState: function() {
+      const city = this.leadDataState?.data?.city ?? City.unknown;
+      this.showLslr = city != null && LSLR_CITY_LINKS.get(city) != null;
     },
   },
 });
 </script>
 
-<style scoped lang="scss">
+<style scoped lang='scss'>
 @import '../assets/styles/global.scss';
 @import '@blueconduit/copper/scss/01_settings/design-tokens';
 


### PR DESCRIPTION
## Description

Adds LSLR section to scorecard page.

This requires adding city to the  API response and populating with the correct value on the insert lambda.

Additionally adds geoType to URL when searching from landing page. This triggers a parcel lookup when the user searches by address.

### New

- LSLR section component

## Testing and Reviewing

Deployed API changes and ran locally to test full stack. Tested searching both an address with a LSLR link and without to test the toggling.