### PR TITLE
Use bbox col to speed up tile query exec time

### DIFF
--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -26,11 +26,17 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+-- Some of our spatial indexes are ignored because we have few rows relative to the volume of
+-- geometry data (see https://postgis.net/docs/manual-1.3/ch05.html). One solution is to cache
+-- the bounding boxes of the geometries associated with each row, making an 'explicit' spatial
+-- index. This function adds a bounding box (named bbox) to any row it is given that also
+-- contains a column named named 'geom' of type geometry. It is used to ensure that water_systems
+-- have a bbox column that can be used to speed up queries when the spatial index is ignored.
 CREATE OR REPLACE FUNCTION set_bbox_to_envelope_of_geom()
     RETURNS TRIGGER AS
 $$
 BEGIN
-    NEW.bbox = ST_Envelope(geom);
+    NEW.bbox = ST_Envelope(new.geom);
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;

--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -26,6 +26,15 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+CREATE OR REPLACE FUNCTION set_bbox_to_envelope_of_geom()
+    RETURNS TRIGGER AS
+$$
+BEGIN
+    NEW.bbox = ST_Envelope(geom);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
 ------------
 -- Tables --
 ------------
@@ -157,11 +166,17 @@ CREATE TABLE IF NOT EXISTS water_systems
     service_connections_count real,
     population_served         real,
     state_census_geo_id       varchar(255) references states (census_geo_id),
+    bbox                      GEOMETRY(Geometry, 4326, 2),
     geom                      GEOMETRY(Geometry, 4326),
     PRIMARY KEY (pws_id)
 );
 CREATE INDEX IF NOT EXISTS water_systems_state_census_geo_id_idx ON water_systems (state_census_geo_id);
 CREATE INDEX IF NOT EXISTS water_systems_geom_idx ON water_systems USING GIST (geom);
+SELECT safe_create($$CREATE TRIGGER set_bbox_to_envelope_of_geom_on_water_system_insertion
+    BEFORE INSERT
+    ON water_systems
+    FOR EACH ROW
+EXECUTE PROCEDURE set_bbox_to_envelope_of_geom()$$);
 
 -- EPA violations data
 
@@ -406,7 +421,7 @@ BEGIN
                         SUM(w.service_connections_count)       AS service_connections_count,
                         SUM(w.population_served)               AS population_served
                  FROM water_systems w
-                 WHERE ST_Transform(w.geom, 3857) && ST_TileEnvelope(z, x, y)
+                 WHERE ST_Transform(w.bbox, 3857) && ST_TileEnvelope(z, x, y)
                  GROUP BY w.geom,
                           w.pws_id,
                           w.pws_name

--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -172,6 +172,7 @@ CREATE TABLE IF NOT EXISTS water_systems
 );
 CREATE INDEX IF NOT EXISTS water_systems_state_census_geo_id_idx ON water_systems (state_census_geo_id);
 CREATE INDEX IF NOT EXISTS water_systems_geom_idx ON water_systems USING GIST (geom);
+CREATE INDEX IF NOT EXISTS water_systems_bbox_idx ON public.water_systems USING gist (bbox);
 SELECT safe_create($$CREATE TRIGGER set_bbox_to_envelope_of_geom_on_water_system_insertion
     BEFORE INSERT
     ON water_systems


### PR DESCRIPTION
## Description

Addresses: [Add bbox column to water_systems to decrease query execution time](https://tables.area120.google.com/table/bX_kMNBW8LA35n6l5Hz_co/row/a9-JMkJQeqe3_9Dpwnm46L)

- Because of [known postgres bugs to do with the shape of our water-systems data](https://postgis.net/docs/manual-1.3/ch05.html), out GIST indexes are being ignored in our tileserver queries, leading to slow execution times. 
- This PR 'caches' the data that *would* be stored in our GIST index in a separate 'bbox' column.
- This leads to an overall decrease in execution time from ~2.5 seconds to ~0.5 seconds for queries at zoom levels 7+.
- There are other improvements we can make, but in terms of effort-vs-reward, this is probably our highest ROI solution.

### New

- schema.sql introduces as new stored procedure `set_bbox_to_envelope_of_geom`, which sets the value of the `bbox` column to the bounding box of whatever geometry is in the `geom` column
- We also introduce a new trigger `set_bbox_to_envelope_of_geom_on_water_system_insertion`, to call `set_bbox_to_envelope_of_geom` on every insertion into the `water_systems` table
- Note: simply updating a `create table if not exists` statement doesn't work since the table will already exist. What we really need is an `alter table` statement to run _after_ schema.sql. I'm not sure how to address this without adding either proper support for migrations, or some serious IF-statement hackery. 
- For now, folks can work around this by just running the following after this PR gets merged:

```sql
SELECT AddGeometryColumn('water_systems','bbox', 4326,'GEOMETRY', 2); 
UPDATE public.water_systems set bbox = ST_Envelope(geom);
CREATE INDEX water_systems_bbox_idx ON public.water_systems USING gist (bbox);
```

### Changed

- The stored procedure `` now uses the new `bbox` column for spatial `&&` queries instead of the `geom` column

### Removed

- None

## Testing and Reviewing

- To test live, point your client to `https://rsrogers.leadout-sandbox.blueconduit.com`
- To quantify the improvements, do the following:
  - Load the default national map
  - Zoom to level 9
  - Wait for everything to load
  - Begin recording network events
  - Scroll north-west until ~20 tiles have loaded
  - Note the loading time of those tiles
- The results of this before and after this change are shown below

### Before

```
191.pbf	200	fetch	d6eebabd-8c7e-4df9-be59-0608f22c0b1a:1	1.8 kB	5.85 s	
191.pbf	200	fetch	d6eebabd-8c7e-4df9-be59-0608f22c0b1a:1	1.2 kB	5.70 s	
191.pbf	200	fetch	d6eebabd-8c7e-4df9-be59-0608f22c0b1a:1	1.8 kB	5.78 s	
190.pbf	200	fetch	d6eebabd-8c7e-4df9-be59-0608f22c0b1a:1	1.1 kB	5.36 s	
190.pbf	200	fetch	d6eebabd-8c7e-4df9-be59-0608f22c0b1a:1	1.4 kB	5.45 s	
190.pbf	200	fetch	d6eebabd-8c7e-4df9-be59-0608f22c0b1a:1	925 B	5.37 s	
95.pbf	200	fetch	d6eebabd-8c7e-4df9-be59-0608f22c0b1a:1	1.9 kB	6.04 
```

### After

```
192.pbf	200	fetch	a7d198b1-49a0-45ce-a429-a44ab2c2e276:1	3.0 kB	30 ms
192.pbf	200	fetch	a7d198b1-49a0-45ce-a429-a44ab2c2e276:1	1.9 kB	28 ms
193.pbf	200	fetch	a7d198b1-49a0-45ce-a429-a44ab2c2e276:1	1.4 kB	625 ms
194.pbf	200	fetch	a7d198b1-49a0-45ce-a429-a44ab2c2e276:1	1.3 kB	658 ms
191.pbf	200	fetch	a7d198b1-49a0-45ce-a429-a44ab2c2e276:1	1.8 kB	41 ms
192.pbf	200	fetch	a7d198b1-49a0-45ce-a429-a44ab2c2e276:1	805 B	636 ms
191.pbf	200	fetch	a7d198b1-49a0-45ce-a429-a44ab2c2e276:1	1.3 kB	650 ms
193.pbf	200	fetch	a7d198b1-49a0-45ce-a429-a44ab2c2e276:1	1.3 kB	520 ms
190.pbf	200	fetch	a7d198b1-49a0-45ce-a429-a44ab2c2e276:1	726 B	32 ms	
```