### PR TITLE
Drop smaller polygons at distant zoom levels

### DIFF
--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -46,7 +46,7 @@ CREATE OR REPLACE FUNCTION set_approx_area_sqkm_to_area_of_geom()
     RETURNS TRIGGER AS
 $$
 BEGIN
-    NEW.approx_area_sq_km = ST_Area(ST_Transform(new.geom, 3857)) / 1000000;
+    NEW.approx_area_sq_km = ST_Area(ST_Transform(new.geom, 4326)) / 1000000;
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;

--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -6,6 +6,20 @@ CREATE EXTENSION IF NOT EXISTS postgis;
 
 -- Function for object creates without existence safety
 
+-- Note on SRIDs.
+-- We use two SRID: 4326 and 3857
+--
+-- 4326 is a 3D coordinate system. Lat/Longs are implicitly converted to 3D space for the
+-- purposes of any calculations, including distances and areas. There is no way to display
+-- 4326 coordinates in 2D without projecting it into 2D in some way or another.
+--
+-- 3857 is a 2D projected coordinate system. When doing anything with tiles, we need them to
+-- be projected into two dimensions (because tiles are shown as squares), so all tile-related
+-- methods either implicitly cast coordinates to 3857 (e.g. ST_TileEnvelope, ST_AsMVT) or
+-- *should* cast them to 3857 for comparison. E.g., to compare a bounding box or other geometry
+--  with a tile from ST_TileEnvelope or ST_AsMVT, we should use ST_Transform to translate it
+-- from 4326 to 3857.
+
 CREATE OR REPLACE FUNCTION safe_create(command TEXT)
     RETURNS void
 AS


### PR DESCRIPTION
## Description

Addresses: [Complete low-hanging-fruit DB optimizations for tile serving](https://tables.area120.google.com/table/bX_kMNBW8LA35n6l5Hz_co/row/blYIQsdPnww7YU8xsoy_aD)

- Some queries fail with the error `Database returned more than the allowed response size limit`
- This PR addresses the error by filtering out smaller polygons at farther zoom levels
- This has a negligible effect on query performance
- Again, since we can't alter tables by re-running schema.sql, you'll have to run the following manually after this is merged:

```sql
ALTER TABLE public.water_systems ADD COLUMN approx_area_sq_km REAL;
UPDATE public.water_systems SET approx_area_sq_km = ST_Area(ST_Transform(geom, 4326)) / 1000000;
CREATE INDEX ON water_systems USING BTREE (approx_area_sq_km);
```

### New

- None

### Changed

- Queries at the following zoom levels only return polygons with square-kilometer sizes greater than specified below
```
zoom | min_area_sq_km
-----+---------------
 <5  | Infinity
 5   | 100
 7   | 10
 8   | 5
 >8  | 0
```

### Removed

- None

## Testing and Reviewing

- Set `VUE_APP_DEFAULT_TILESERVER_HOST=rsrogers.leadout-sandbox.blueconduit.com` in your `.env`
- Scroll around the nationwide map. You shouldn't notice water systems obviously missing, and you also shouldn't see any failed requests in the network tab on the dev console. 
- Check that schema.sql doesn't freak out [here](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Flambda$252Frsrogers-OpenDataPlatform-RootSchemahandler909455B-PWnu0M0oqt3N/log-events/2022$252F08$252F27$252F$255B$2524LATEST$255De8d9547083ba464db6fa62c8d0fc8371)
- Delete and reimport water systems and check that it worked. 