### PR TITLE
Use BC's GA account ID

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <!-- Conditionally include Google Analytics snippet, if targetting production -->
     <% if (process.env.NODE_ENV === 'production') { %>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-149759341-1"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-146085874-1"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag() {
@@ -11,7 +11,7 @@
       }
       gtag('js', new Date());
 
-      gtag('config', 'UA-149759341-1');
+      gtag('config', 'UA-146085874-1');
     </script>
     <% } %>
 

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <!-- Conditionally include Google Analytics snippet, if targetting production -->
     <% if (process.env.NODE_ENV === 'production') { %>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y3Y8TPP27F"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=300502251"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag() {
@@ -11,7 +11,7 @@
       }
       gtag('js', new Date());
 
-      gtag('config', 'G-Y3Y8TPP27F');
+      gtag('config', '300502251');
     </script>
     <% } %>
 

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <!-- Conditionally include Google Analytics snippet, if targetting production -->
     <% if (process.env.NODE_ENV === 'production') { %>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=300502251"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-149759341-1"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag() {
@@ -11,7 +11,7 @@
       }
       gtag('js', new Date());
 
-      gtag('config', '300502251');
+      gtag('config', 'UA-149759341-1');
     </script>
     <% } %>
 


### PR DESCRIPTION
## Description

Addresses: [Switch GA to use BC's account](https://tables.area120.google.com/table/bX_kMNBW8LA35n6l5Hz_co/row/aXx97ZAfHxzdYvhNHytkk6)

This switches the Google Analytics ID to [BC's account](https://lslr.slack.com/archives/C03D8ECRC3S/p1661276665032239?thread_ts=1660938852.883329&cid=C03D8ECRC3S).

### Changed

- GA ID.

## Testing and Reviewing

My [sandbox](https://beekley.leadout-sandbox.blueconduit.com/) didn't yell at my when I deployed this. But I don't have access to the GA dashboard to test that data is flowing.
