### PR TITLE
Add deployments-monitoring to the pipeline.

### DIFF
--- a/cdk/src/pipeline.ts
+++ b/cdk/src/pipeline.ts
@@ -10,7 +10,7 @@ import { PipelineStack } from './pipeline/pipeline-stack';
 const app = new cdk.App();
 
 new PipelineStack(app, `${util.projectName}Pipeline`, {
-  // Deployment account.
+  // Deployments account.
   env: { account: '223904267317', region: 'us-east-2' },
-  tags: { Project: util.projectName, Environment: 'Deployments' },
+  tags: { Project: util.projectName, Environment: util.EnvType.Deployments },
 });

--- a/cdk/src/pipeline/pipeline-stack.ts
+++ b/cdk/src/pipeline/pipeline-stack.ts
@@ -57,6 +57,20 @@ export class PipelineStack extends Stack {
       },
     });
 
+    // Monitor this release pipeline itself.
+    pipeline.addStage(
+      new MonitoringStage(this, 'Deployments-Monitoring', {
+        ...props,
+        envType: util.EnvType.Deployments,
+        slackConfig: {
+          slackChannelConfigurationName: `${util.EnvType.Deployments}-${util.projectName}-channel-config`,
+          slackWorkspaceId: 'TJTFN34NM',
+          // #leadout-deployment-notifications
+          slackChannelId: 'C0406KX4DPC',
+        },
+      }),
+    );
+
     pipeline.addStage(
       new MonitoringStage(this, 'Dev-Monitoring', {
         env: { account: '036999211278', region: 'us-east-2' },

--- a/cdk/src/util.ts
+++ b/cdk/src/util.ts
@@ -18,6 +18,7 @@ export enum EnvType {
   Sandbox = 'SANDBOX', // Developers' individual environments.
   Development = 'DEV', // Single shared dev environment.
   Production = 'PROD', // Not yet implemented.
+  Deployments = 'Deployments', // Title-case string matches the existing deployments tag.
 }
 export const defaultEnv = EnvType.Sandbox;
 export const projectName = 'OpenDataPlatform';


### PR DESCRIPTION
## Description

Addresses: [Dev has monitoring](https://tables.area120.google.com/table/bX_kMNBW8LA35n6l5Hz_co/row/bYcpg5d5BPEdlvjUIGh_gZ)

This PR sets up monitoring for the deployments AWS account itself. A future PR will start monitoring stuff, but that can't happen until this is merged in and the SNS topic exists.

### New

- Deployments-monitoring pipeline stage

### Changed

- light enum changes.

## Testing and Reviewing

This successfully compiles via `npm run pipeline-synth`. But we won't know if it works until it's merged and deployed.
