### PR TITLE
Alert on pipeline failure.

### DIFF
--- a/cdk/src/open-data-platform/app-plane/api/api-monitoring.ts
+++ b/cdk/src/open-data-platform/app-plane/api/api-monitoring.ts
@@ -1,0 +1,78 @@
+import { Construct } from 'constructs';
+import { RestApi } from 'aws-cdk-lib/aws-apigateway';
+import { Duration } from 'aws-cdk-lib';
+import { ITopic } from 'aws-cdk-lib/aws-sns';
+import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
+import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
+
+interface ApiMonitoringProps {
+  gateway: RestApi;
+  ticketSNSTopic?: ITopic;
+}
+
+export class ApiMonitoring extends Construct {
+  constructor(scope: Construct, id: string, props: ApiMonitoringProps) {
+    super(scope, id);
+
+    const { gateway, ticketSNSTopic } = props;
+
+    // Client errors are likely caused by problems in our client code since the API is not public,
+    // so they should be considered like an internal error.
+    // TODO: Split this into client and server errors once the API is pubished.
+    // TODO: Track the error budget, rather than looking at the error rate at any given time.
+
+    const availabilitySlo = 0.95;
+    const latencyMsSlo = 2000; // Miliseconds
+    const slowBurnPeriod = Duration.days(1);
+    const fastBurnPeriod = Duration.hours(1);
+
+    const alarms = [
+      new cloudwatch.MathExpression({
+        expression: '(clientError + serverError) / count',
+        label: 'Error Fraction',
+        period: slowBurnPeriod,
+        usingMetrics: {
+          clientError: gateway.metricClientError(),
+          serverError: gateway.metricServerError(),
+          count: gateway.metricCount(),
+        },
+      }).createAlarm(scope, 'AvailabilitySLOSlowBurn', {
+        alarmDescription: `The API has been running below its ${
+          availabilitySlo * 100
+        }% SLO for ${slowBurnPeriod.toString()}.`,
+        evaluationPeriods: 1,
+        threshold: 1 - availabilitySlo,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      }),
+
+      new cloudwatch.MathExpression({
+        expression: '(clientError + serverError) / count',
+        label: 'Error Fraction',
+        period: fastBurnPeriod,
+        usingMetrics: {
+          clientError: gateway.metricClientError(),
+          serverError: gateway.metricServerError(),
+          count: gateway.metricCount(),
+        },
+      }).createAlarm(scope, 'AvailabilitySLOFastBurn', {
+        alarmDescription: `The API has been running significantly below its ${
+          availabilitySlo * 100
+        }% SLO for ${fastBurnPeriod.toString()}.`,
+        evaluationPeriods: 1,
+        threshold: (1 - availabilitySlo) * 10, // 10x error rate than SLO allows.
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      }),
+
+      // TODO: This uses average latency. Additionally alert on 95%ile latency over a longer period.
+      gateway.metricLatency({ period: fastBurnPeriod }).createAlarm(scope, 'LatencySLOFastBurn', {
+        alarmDescription: `The API has a higher latency than its ${latencyMsSlo} ms SLO for ${fastBurnPeriod.toString()}.`,
+        evaluationPeriods: 1,
+        threshold: latencyMsSlo,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      }),
+    ];
+
+    if (ticketSNSTopic)
+      alarms.forEach((alarm) => alarm.addAlarmAction(new SnsAction(ticketSNSTopic)));
+  }
+}

--- a/cdk/src/open-data-platform/app-plane/api/api-stack.ts
+++ b/cdk/src/open-data-platform/app-plane/api/api-stack.ts
@@ -2,6 +2,7 @@ import * as apigateway from 'aws-cdk-lib/aws-apigateway';
 import { Construct } from 'constructs';
 import prefixes from '../../frontend/url-prefixes';
 import { AppPlaneStackProps } from '../app-plane-stack';
+import { ApiMonitoring } from './api-monitoring';
 import { apiLambdaFactory } from './lambda-function-factory';
 
 export class ApiStack extends Construct {
@@ -10,7 +11,7 @@ export class ApiStack extends Construct {
   constructor(scope: Construct, id: string, props: AppPlaneStackProps) {
     super(scope, id);
 
-    const { dataPlaneStack, networkStack } = props;
+    const { dataPlaneStack, networkStack, ticketSNSTopic } = props;
 
     this.gateway = new apigateway.RestApi(this, 'API', {
       // TODO: Lock this down for non-sandbox environments.
@@ -48,5 +49,7 @@ export class ApiStack extends Construct {
       'GET',
       '/zipcode/scorecard/{zipcode+}',
     );
+
+    new ApiMonitoring(this, 'APIMonitoring', { gateway: this.gateway, ticketSNSTopic });
   }
 }

--- a/cdk/src/open-data-platform/app-plane/app-plane-stack.ts
+++ b/cdk/src/open-data-platform/app-plane/app-plane-stack.ts
@@ -7,12 +7,14 @@ import { DataPlaneStack } from '../data-plane/data-plane-stack';
 import { NetworkStack } from '../network/network-stack';
 import { TileServer } from './tileserver/tileserver';
 import { ApiStack } from './api/api-stack';
+import { ITopic } from 'aws-cdk-lib/aws-sns';
 
 // TODO: consider narrowing the props down to the specific things that the App Plane needs.
 // E.g. just the cluster object itself, rather than the entire network stack.
 export interface AppPlaneStackProps extends CommonProps {
   networkStack: NetworkStack;
   dataPlaneStack: DataPlaneStack;
+  ticketSNSTopic?: ITopic;
 }
 
 export class AppPlaneStack extends Stack {

--- a/cdk/src/pipeline/pipeline-stack.ts
+++ b/cdk/src/pipeline/pipeline-stack.ts
@@ -7,6 +7,10 @@ import * as pipelines from 'aws-cdk-lib/pipelines';
 import * as util from '../util';
 import { MonitoringStage, OpenDataPlatformStage } from './stage';
 import { BuildSpec, LinuxBuildImage } from 'aws-cdk-lib/aws-codebuild';
+import { Topic } from 'aws-cdk-lib/aws-sns';
+import { env } from 'process';
+import { topicArn } from '../monitoring/monitoring-stack';
+import { DetailType, NotificationRule } from 'aws-cdk-lib/aws-codestarnotifications';
 
 const CODE_REPO = 'BlueConduit/open-data-platform';
 const CODE_CONNECTION_ARN =
@@ -92,5 +96,25 @@ export class PipelineStack extends Stack {
         envType: util.EnvType.Development,
       }),
     );
+
+    // Add monitoring.
+    // This will fail if the monitoring stage has not yet completed.
+    const ticketSNSTopic = Topic.fromTopicArn(
+      this,
+      'ticketSNSTopic',
+      topicArn(util.EnvType.Deployments, env),
+    );
+
+    new NotificationRule(this, 'FailureNotification', {
+      detailType: DetailType.BASIC,
+      // These are events that stop the pipeline, except in the 'superseded' case where another
+      // execution took precedence.
+      events: [
+        'codepipeline-pipeline-pipeline-execution-failed',
+        'codepipeline-pipeline-pipeline-execution-canceled',
+      ],
+      source: pipeline.pipeline,
+      targets: [ticketSNSTopic],
+    });
   }
 }

--- a/cdk/src/pipeline/pipeline-stack.ts
+++ b/cdk/src/pipeline/pipeline-stack.ts
@@ -105,6 +105,7 @@ export class PipelineStack extends Stack {
       topicArn(util.EnvType.Deployments, env),
     );
 
+    pipeline.buildPipeline(); // `pipeline.pipeline` below is only available after build.
     new NotificationRule(this, 'FailureNotification', {
       detailType: DetailType.BASIC,
       // These are events that stop the pipeline, except in the 'superseded' case where another


### PR DESCRIPTION
## Description

Addresses: [Dev has monitoring](https://tables.area120.google.com/table/bX_kMNBW8LA35n6l5Hz_co/row/bYcpg5d5BPEdlvjUIGh_gZ)

Currently, devs have to manually check if a deployment succeeded. This PR adds a notification if the deployment pipeline failed.

I considered notifying on any changes, but that's noisy. I want to keep the signal:noise ratio high for the notifications Slack channels, which means they should only have messages if there is a problem. If it'd be useful to also notify on success, we can have another channel for that.

### New

- Notification on pipeline failure

## Testing and Reviewing

This successfully compiles via `npm run pipeline-synth`. But we won't know if it works until it's merged and deployed.