### PR TITLE
Add monitoring for API.

### DIFF
--- a/cdk/src/open-data-platform/app-plane/api/api-monitoring.ts
+++ b/cdk/src/open-data-platform/app-plane/api/api-monitoring.ts
@@ -1,0 +1,78 @@
+import { Construct } from 'constructs';
+import { RestApi } from 'aws-cdk-lib/aws-apigateway';
+import { Duration } from 'aws-cdk-lib';
+import { ITopic } from 'aws-cdk-lib/aws-sns';
+import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
+import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
+
+interface ApiMonitoringProps {
+  gateway: RestApi;
+  ticketSNSTopic?: ITopic;
+}
+
+export class ApiMonitoring extends Construct {
+  constructor(scope: Construct, id: string, props: ApiMonitoringProps) {
+    super(scope, id);
+
+    const { gateway, ticketSNSTopic } = props;
+
+    // Client errors are likely caused by problems in our client code since the API is not public,
+    // so they should be considered like an internal error.
+    // TODO: Split this into client and server errors once the API is pubished.
+    // TODO: Track the error budget, rather than looking at the error rate at any given time.
+
+    const availabilitySlo = 0.95;
+    const latencyMsSlo = 2000; // Miliseconds
+    const slowBurnPeriod = Duration.days(1);
+    const fastBurnPeriod = Duration.hours(1);
+
+    const alarms = [
+      new cloudwatch.MathExpression({
+        expression: '(clientError + serverError) / count',
+        label: 'Error Fraction',
+        period: slowBurnPeriod,
+        usingMetrics: {
+          clientError: gateway.metricClientError(),
+          serverError: gateway.metricServerError(),
+          count: gateway.metricCount(),
+        },
+      }).createAlarm(scope, 'AvailabilitySLOSlowBurn', {
+        alarmDescription: `The API has been running below its ${
+          availabilitySlo * 100
+        }% SLO for ${slowBurnPeriod.toString()}.`,
+        evaluationPeriods: 1,
+        threshold: 1 - availabilitySlo,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      }),
+
+      new cloudwatch.MathExpression({
+        expression: '(clientError + serverError) / count',
+        label: 'Error Fraction',
+        period: fastBurnPeriod,
+        usingMetrics: {
+          clientError: gateway.metricClientError(),
+          serverError: gateway.metricServerError(),
+          count: gateway.metricCount(),
+        },
+      }).createAlarm(scope, 'AvailabilitySLOFastBurn', {
+        alarmDescription: `The API has been running significantly below its ${
+          availabilitySlo * 100
+        }% SLO for ${fastBurnPeriod.toString()}.`,
+        evaluationPeriods: 1,
+        threshold: (1 - availabilitySlo) * 10, // 10x error rate than SLO allows.
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      }),
+
+      // TODO: This uses average latency. Additionally alert on 95%ile latency over a longer period.
+      gateway.metricLatency({ period: fastBurnPeriod }).createAlarm(scope, 'LatencySLOFastBurn', {
+        alarmDescription: `The API has a higher latency than its ${latencyMsSlo} ms SLO for ${fastBurnPeriod.toString()}.`,
+        evaluationPeriods: 1,
+        threshold: latencyMsSlo,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      }),
+    ];
+
+    if (ticketSNSTopic)
+      alarms.forEach((alarm) => alarm.addAlarmAction(new SnsAction(ticketSNSTopic)));
+  }
+}

--- a/cdk/src/open-data-platform/app-plane/api/api-stack.ts
+++ b/cdk/src/open-data-platform/app-plane/api/api-stack.ts
@@ -2,6 +2,7 @@ import * as apigateway from 'aws-cdk-lib/aws-apigateway';
 import { Construct } from 'constructs';
 import prefixes from '../../frontend/url-prefixes';
 import { AppPlaneStackProps } from '../app-plane-stack';
+import { ApiMonitoring } from './api-monitoring';
 import { apiLambdaFactory } from './lambda-function-factory';
 
 export class ApiStack extends Construct {
@@ -10,7 +11,7 @@ export class ApiStack extends Construct {
   constructor(scope: Construct, id: string, props: AppPlaneStackProps) {
     super(scope, id);
 
-    const { dataPlaneStack, networkStack } = props;
+    const { dataPlaneStack, networkStack, ticketSNSTopic } = props;
 
     this.gateway = new apigateway.RestApi(this, 'API', {
       // TODO: Lock this down for non-sandbox environments.
@@ -48,5 +49,7 @@ export class ApiStack extends Construct {
       'GET',
       '/zipcode/scorecard/{zipcode+}',
     );
+
+    new ApiMonitoring(this, 'APIMonitoring', { gateway: this.gateway, ticketSNSTopic });
   }
 }

--- a/cdk/src/open-data-platform/app-plane/app-plane-stack.ts
+++ b/cdk/src/open-data-platform/app-plane/app-plane-stack.ts
@@ -7,12 +7,14 @@ import { DataPlaneStack } from '../data-plane/data-plane-stack';
 import { NetworkStack } from '../network/network-stack';
 import { TileServer } from './tileserver/tileserver';
 import { ApiStack } from './api/api-stack';
+import { ITopic } from 'aws-cdk-lib/aws-sns';
 
 // TODO: consider narrowing the props down to the specific things that the App Plane needs.
 // E.g. just the cluster object itself, rather than the entire network stack.
 export interface AppPlaneStackProps extends CommonProps {
   networkStack: NetworkStack;
   dataPlaneStack: DataPlaneStack;
+  ticketSNSTopic?: ITopic;
 }
 
 export class AppPlaneStack extends Stack {


### PR DESCRIPTION
## Description

Addresses: [Dev has monitoring](https://tables.area120.google.com/table/bX_kMNBW8LA35n6l5Hz_co/row/bYcpg5d5BPEdlvjUIGh_gZ) (based on the [Production Design](https://docs.google.com/document/d/1zZxCoXx5JzLXTOGVdvC4s8H-r82DFjfmNU-dmFPAQVI/edit#heading=h.cj0jtq6gzcgp))

This PR adds metrics and alarms the error rate for the entire API gateway. It's a bit of a naive implementation, since it smashes together all endpoints and all error codes. But I like that simplicity for now-- we can split it up into granular metrics in the future as we find it useful.

This defines alarms for "slow burn" (low error rate, but long duration) and "fast burn" (high error rate over a short duration). That way we can get an early warning of problems, but also see long-term issues too.

I have a feeling this is going to be noisy. But that might be a good thing. We can tune it as necessary.

### New

- Metrics and alarms for the API gateway.

## Testing and Reviewing

The alarms show up ([example](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#alarmsV2:alarm/beekley-OpenDataPlatformAppPlane-ApiStackAvailabilitySLOSlowBurn70D70F36-1NMZZJY6RA9A3?)) in my sandbox.
