### PR TITLE
Small UI fixes

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -83,5 +83,6 @@ body,
 #app,
 .main {
   height: 100%;
+  min-width: 1105px;
 }
 </style>

--- a/client/src/components/NationwideMap.vue
+++ b/client/src/components/NationwideMap.vue
@@ -109,6 +109,10 @@ export default defineComponent({
       default: DEFAULT_LNG_LAT,
     },
     height: { type: String, default: '80vh' },
+    restrictBoundsOnResult: {
+      type: Boolean,
+      default: false,
+    },
   },
   methods: {
     zoomToLongLat() {
@@ -126,7 +130,9 @@ export default defineComponent({
         ];
 
         this.map?.fitBounds(lngLatBounds);
-        this.map?.setMaxBounds(lngLatBounds);
+        if (this.restrictBoundsOnResult) {
+          this.map?.setMaxBounds(lngLatBounds);
+        }
       } else if (this.geoState?.geoids?.lat != null && this.geoState?.geoids.long != null) {
         const lonLat: LngLatLike = {
           lon: parseInt(this.geoState?.geoids?.long),
@@ -386,7 +392,9 @@ export default defineComponent({
         }
         this.zoomToLongLat();
       } else {
-        this.map?.setMaxBounds(); // Removes max bounds.
+        if (this.restrictBoundsOnResult) {
+          this.map?.setMaxBounds(); // Removes max bounds.
+        }
         // Reset map to full view of U.S. when geo IDs are cleared.
         if (this.map?.isStyleLoaded()) {
           this.map?.jumpTo({

--- a/client/src/components/NationwideMap.vue
+++ b/client/src/components/NationwideMap.vue
@@ -6,8 +6,7 @@
 </template>
 
 <script lang='ts'>
-import mapboxgl from 'mapbox-gl';
-import mapbox, { LngLatBounds, LngLatLike, MapLayerMouseEvent } from 'mapbox-gl';
+import mapboxgl, { LngLatBounds, LngLatLike, MapLayerMouseEvent } from 'mapbox-gl';
 import MapLegend from './MapLegend.vue';
 import MapPopupContent from './MapPopupContent.vue';
 import { createApp, defineComponent, nextTick, PropType } from 'vue';
@@ -28,6 +27,9 @@ const VISIBLE = 'visible';
 const PARCEL_ZOOM_LEVEL = 12;
 const DEFAULT_ZOOM_LEVEL = 4;
 
+// Define Toledo geometry bounding box to restrict parcel data layer to Toledo.
+// This is needed because we only have parcel-level predictions for Toledo, so this data layer will
+// be empty outside of these boundaries.
 const TOLEDO_BOUNDS: [LngLatLike, LngLatLike] = [
   [-84.3995471043526, 41.165751],
   [-82.711584, 41.742764],
@@ -42,7 +44,7 @@ export default defineComponent({
     MapLegend,
   },
   setup() {
-    mapbox.accessToken = process.env.VUE_APP_MAP_BOX_API_TOKEN ?? '';
+    mapboxgl.accessToken = process.env.VUE_APP_MAP_BOX_API_TOKEN ?? '';
 
     // Listen to geoState updates.
     const geoState = useSelector((state) => state.geos) as GeoDataState;
@@ -204,7 +206,7 @@ export default defineComponent({
      */
     createMapPopup(lngLat: LngLatLike, popupData: Record<string, any>): void {
       if (this.map == null) return;
-      this.popup = new mapbox.Popup({ className: 'mapbox-popup' })
+      this.popup = new mapboxgl.Popup({ className: 'mapbox-popup' })
         .setLngLat(lngLat)
         .setHTML(POPUP_CONTENT_BASE_HTML) // Add basic div to mount to.
         .addTo(this.map);
@@ -337,7 +339,7 @@ export default defineComponent({
      * layers.
      */
     async createMap(): Promise<void> {
-      this.map = new mapbox.Map({
+      this.map = new mapboxgl.Map({
         // Removes watermark by Mapbox.
         attributionControl: false,
         center: this.center,
@@ -347,13 +349,13 @@ export default defineComponent({
         dragPan: !this.restrictBoundsOnResult,
       });
 
-      this.map.on('load', this.configureMap);
-      this.map.on('error', (error) => {
+      this.map?.on('load', this.configureMap);
+      this.map?.on('error', (error) => {
         console.log(`Error loading tiles: ${error.error} `);
         console.log(error.error.stack);
       });
 
-      this.map.scrollZoom.disable();
+      this.map?.scrollZoom.disable();
       dispatch(setZoom(DEFAULT_ZOOM_LEVEL));
     },
   },

--- a/client/src/components/NationwideMap.vue
+++ b/client/src/components/NationwideMap.vue
@@ -130,9 +130,6 @@ export default defineComponent({
         ];
 
         this.map?.fitBounds(lngLatBounds);
-        if (this.restrictBoundsOnResult) {
-          this.map?.setMaxBounds(lngLatBounds);
-        }
       } else if (this.geoState?.geoids?.lat != null && this.geoState?.geoids.long != null) {
         const lonLat: LngLatLike = {
           lon: parseInt(this.geoState?.geoids?.long),
@@ -347,6 +344,7 @@ export default defineComponent({
         container: 'map-container',
         style: 'mapbox://styles/blueconduit/cku6hkwe72uzz19s75j1lxw3x?optimize=true',
         zoom: DEFAULT_ZOOM_LEVEL,
+        dragPan: !this.restrictBoundsOnResult,
       });
 
       this.map.on('load', this.configureMap);
@@ -392,9 +390,6 @@ export default defineComponent({
         }
         this.zoomToLongLat();
       } else {
-        if (this.restrictBoundsOnResult) {
-          this.map?.setMaxBounds(); // Removes max bounds.
-        }
         // Reset map to full view of U.S. when geo IDs are cleared.
         if (this.map?.isStyleLoaded()) {
           this.map?.jumpTo({

--- a/client/src/components/NationwideMap.vue
+++ b/client/src/components/NationwideMap.vue
@@ -114,10 +114,14 @@ export default defineComponent({
           maxLat,
           maxLon,
         } = this.geoState?.geoids?.pwsId?.bounding_box;
-        this.map?.fitBounds([
+
+        const lngLatBounds: [LngLatLike, LngLatLike] = [
           [minLat, minLon],
           [maxLat, maxLon],
-        ]);
+        ];
+
+        this.map?.fitBounds(lngLatBounds);
+        this.map?.setMaxBounds(lngLatBounds);
       } else if (this.geoState?.geoids?.lat != null && this.geoState?.geoids.long != null) {
         const lonLat: LngLatLike = {
           lon: parseInt(this.geoState?.geoids?.long),

--- a/client/src/components/PredictionPanel.vue
+++ b/client/src/components/PredictionPanel.vue
@@ -20,12 +20,20 @@
           formatPredictionAsLikelihoodDescriptor(publicLeadPercent)) }}
         </div>
       </div>
-      <div class='no-prediction' v-if='!showPrediction'>
+      <div class='no-prediction' v-if='showNoPrediction'>
         <div class='h1-header-xl navy'>
           {{ ScorecardSummaryMessages.NOT_ENOUGH_DATA_AVAILABLE }}
         </div>
         <div class='explain-text'>
           {{ ScorecardSummaryMessages.NOT_ENOUGH_DATA_EXPLAINED }}
+        </div>
+      </div>
+      <div v-if='emptyGeoData'>
+        <div class='h1-header-large navy'>
+          {{ ScorecardSummaryMessages.GET_WATER_SCORE }}
+        </div>
+        <div class='explain-text'>
+          {{ ScorecardSummaryMessages.LEAD_LIKELIHOOD_EXPLAINED }}
         </div>
       </div>
       <!--      TODO: show error message when content is finalized and showError is true.-->
@@ -97,8 +105,11 @@ export default defineComponent({
     pwsId(): BoundedGeoDatum | null {
       return this.geoState?.geoids?.pwsId ?? null;
     },
-    showPrediction(): boolean {
-      return (this.showWaterSystemPrediction || this.showParcelPrediction) && !this.showError;
+    emptyGeoData(): boolean {
+      return this.geoState?.geoids?.geoType == null
+        && this.geoState?.geoids?.pwsId == null
+        && this.geoState?.geoids?.address == null
+        && this.geoState?.geoids?.zipCode == null;
     },
     showParcelPrediction(): boolean {
       return this.geoState?.geoids?.geoType == GeoType.address && this.publicLeadLikelihood != null;
@@ -110,6 +121,12 @@ export default defineComponent({
         this.pwsId != null &&
         this.percentLead != null
       );
+    },
+    showPrediction(): boolean {
+      return (this.showWaterSystemPrediction || this.showParcelPrediction) && !this.showError;
+    },
+    showNoPrediction(): boolean {
+      return !this.showPrediction && !this.emptyGeoData;
     },
   },
   watch: {

--- a/client/src/components/PredictionPanel.vue
+++ b/client/src/components/PredictionPanel.vue
@@ -20,15 +20,7 @@
           formatPredictionAsLikelihoodDescriptor(publicLeadPercent)) }}
         </div>
       </div>
-      <div class='no-prediction' v-if='!showPrediction && !showError'>
-        <div class='h1-header-large navy'>
-          {{ ScorecardSummaryMessages.GET_WATER_SCORE }}
-        </div>
-        <div class='explain-text'>
-          {{ ScorecardSummaryMessages.LEAD_LIKELIHOOD_EXPLAINED }}
-        </div>
-      </div>
-      <div v-if='showError'>
+      <div class='no-prediction' v-if='!showPrediction'>
         <div class='h1-header-xl navy'>
           {{ ScorecardSummaryMessages.NOT_ENOUGH_DATA_AVAILABLE }}
         </div>
@@ -36,6 +28,7 @@
           {{ ScorecardSummaryMessages.NOT_ENOUGH_DATA_EXPLAINED }}
         </div>
       </div>
+      <!--      TODO: show error message when content is finalized and showError is true.-->
     </div>
   </div>
 </template>

--- a/client/src/components/PredictionPanel.vue
+++ b/client/src/components/PredictionPanel.vue
@@ -105,6 +105,8 @@ export default defineComponent({
     pwsId(): BoundedGeoDatum | null {
       return this.geoState?.geoids?.pwsId ?? null;
     },
+    // True if and only if there is no current search criteria. This will be false if there is a
+    // search but there is no prediction data for that search.
     emptyGeoData(): boolean {
       return this.geoState?.geoids?.geoType == null
         && this.geoState?.geoids?.pwsId == null
@@ -125,6 +127,8 @@ export default defineComponent({
     showPrediction(): boolean {
       return (this.showWaterSystemPrediction || this.showParcelPrediction) && !this.showError;
     },
+    // This will be true when there is no prediction but there are geo IDs, meaning that there is
+    // just no prediction data for the search criteria.
     showNoPrediction(): boolean {
       return !this.showPrediction && !this.emptyGeoData;
     },

--- a/client/src/views/NationwideMapView.vue
+++ b/client/src/views/NationwideMapView.vue
@@ -1,6 +1,6 @@
 <template>
   <SearchBar />
-  <NationwideMap />
+  <NationwideMap :restrictBoundsOnResult='false' />
 </template>
 
 <script lang='ts'>

--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -6,7 +6,7 @@
                           :acceptedTypes='acceptedTypes'
                           :baseUrl='SCORECARD_BASE'
                           v-model:expandSearch='showSearch' />
-      <NationwideMap height='60vh' />
+      <NationwideMap height='60vh' :restrictBoundsOnResult='true' />
     </div>
     <div class='container-column center-container actions-to-take'>
       <div class='h1-header-large'>
@@ -47,8 +47,7 @@ import ScorecardSummaryPanel from '../components/ScorecardSummaryPanel.vue';
 import { ScorecardMessages } from '../assets/messages/scorecard_messages';
 import { Titles } from '../assets/messages/common';
 import NationwideMap from '../components/NationwideMap.vue';
-import LslrSection from '@/components/LslrSection.vue';
-import { LSLR_CITY_LINKS } from '@/components/LslrSection.vue';
+import LslrSection, { LSLR_CITY_LINKS } from '@/components/LslrSection.vue';
 import { useSelector } from '@/model/store';
 import { LeadDataState } from '../model/states/lead_data_state';
 import { City, GeoType } from '../model/states/model/geo_data';


### PR DESCRIPTION
## Description

Addresses: 

- Restrict pan on map. Disables drag to pan but not zoom functionality yet because we don't have accurate enough zoom for results, so we need to enable to zoom to / from parcel level for Toledo.
- Restrict parcels vue to Toledo: checks bounds of map before switching to parcel view on zoom. This will not switch back and forth between views on panning though, since there is no event to listen for this.
- Set min page width (to avoid wonky responsive views).
- Differentiates between empty state and no prediction state on scorecard. Shows 'no prediction' message when geo IDs are present but no prediction is present. If no geo IDs are present, shows message to prompt a search.

## Testing and Reviewing

Ran locally, tested in Toledo and outside of it. Tried panning around in scorecard view. Tried responsive sizing of page.