### PR TITLE
Fix parcels config to use proper property to read lead + fix zooming

### DIFF
--- a/client/src/api/api_client.ts
+++ b/client/src/api/api_client.ts
@@ -51,8 +51,18 @@ class ApiClient {
   getGeoIds = async (lat: string, long: string): Promise<ApiResponse> => {
     return this.request(`${ApiClient.API_URL}/geolocate/${lat},${long}`, (data) => {
       return {
-        pwsId: data?.data?.water_system_pws_id,
-        zipCode: data?.data?.zip_code,
+        address: {
+          id: data?.data?.address.id,
+          boundingBox: data?.data?.address.bounding_box,
+        },
+        pwsId: {
+          id: data?.data?.water_system_pws_id?.id,
+          boundingBox: data?.data?.water_system_pws_id?.bounding_box,
+        },
+        zipCode: {
+          id: data?.data?.zip_code?.id,
+          boundingBox: data?.data?.zip_code?.bounding_box,
+        },
       };
     });
   };

--- a/client/src/components/NationwideMap.vue
+++ b/client/src/components/NationwideMap.vue
@@ -118,7 +118,7 @@ export default defineComponent({
     },
     zoomToLongLat() {
       const addressBoundingBox = this.geoState?.geoids?.address?.boundingBox;
-      const waterSystemBoundingBox = this.geoState?.geoids?.address?.boundingBox;
+      const waterSystemBoundingBox = this.geoState?.geoids?.pwsId?.boundingBox;
 
       const lat = this.geoState?.geoids?.lat;
       const long = this.geoState?.geoids?.long;
@@ -134,7 +134,7 @@ export default defineComponent({
         const ne = new mapboxgl.LngLat(waterSystemBoundingBox.maxLon, waterSystemBoundingBox.maxLat);
 
         this.map?.fitBounds(new LngLatBounds(sw, ne));
-        
+
         // When there are no bounding boxes available, go to zipcode.
       } else if (lat != null && long != null) {
         const lonLat = this.getLngLatLikeFromLatLong(lat, long);

--- a/client/src/components/PredictionPanel.vue
+++ b/client/src/components/PredictionPanel.vue
@@ -126,8 +126,7 @@ export default defineComponent({
       // Check if an address was queried and another prediction should be
       // fetched.
       if (
-        this.geoState?.geoids?.geoType == GeoType.address &&
-        this.geoState?.geoids?.lat != null &&
+        this.geoState?.geoids?.address != null && this.geoState?.geoids?.lat != null &&
         this.geoState?.geoids?.long != null
       ) {
         dispatch(getParcel(this.geoState.geoids.lat, this.geoState.geoids.long));

--- a/client/src/components/ScorecardSummaryPanel.vue
+++ b/client/src/components/ScorecardSummaryPanel.vue
@@ -122,7 +122,6 @@ export default defineComponent({
     // must be fetched.
     'geoState.geoids.zipCode': function() {
       if (this.geoState?.geoids?.zipCode != null) {
-        dispatch(clearDemographicData());
         dispatch(getDemographicData(GeographicLevel.Zipcode, this.geoState.geoids.zipCode.id));
       }
     },

--- a/client/src/data_layer_configs/lead_service_lines_by_parcel_config.ts
+++ b/client/src/data_layer_configs/lead_service_lines_by_parcel_config.ts
@@ -2,7 +2,6 @@ import {
   DataSourceType,
   FeaturePropertyDataType,
   GeographicLevel,
-  LegendInfo,
   MapLayer,
   PopupInfo,
   TileDataLayer,
@@ -50,7 +49,7 @@ const legend = new Map([
   ],
 ]);
 
-const percentLeadLikelihood = ['*', 100, ['get', 'public_lead_prediction']];
+const percentLeadLikelihood = ['*', 100, ['get', 'public_lead_connections_low_estimate']];
 
 /**
  * Mapbox expression which interpolates pairs of bucket 'stops' + colors to produce continuous
@@ -75,7 +74,7 @@ export const styleLayer: FillLayer = {
   paint: {
     'fill-color': [
       'case',
-      ['==', ['get', 'public_lead_prediction'], null],
+      ['==', ['get', 'public_lead_connections_low_estimate'], null],
       DEFAULT_NULL_COLOR,
       leadConnectionLegendInterpolation,
     ],
@@ -98,8 +97,8 @@ const popupInfo: PopupInfo = {
       dataType: FeaturePropertyDataType.Address,
     },
     {
-      label: 'Lead likelihood',
-      name: 'public_lead_prediction',
+      label: 'Likelihood of lead',
+      name: 'public_lead_connections_low_estimate',
       dataType: FeaturePropertyDataType.Percentage,
     },
   ],

--- a/client/src/model/states/model/geo_data.ts
+++ b/client/src/model/states/model/geo_data.ts
@@ -32,7 +32,7 @@ enum City {
  */
 interface GeoData {
   pwsId?: BoundedGeoDatum;
-  address?: string;
+  address?: BoundedGeoDatum;
   geoType?: GeoType;
   zipCode?: BoundedGeoDatum;
   lat?: string;
@@ -48,7 +48,7 @@ interface BoundingBox {
 
 interface BoundedGeoDatum {
   id: string;
-  bounding_box: BoundingBox;
+  boundingBox: BoundingBox;
 }
 
-export { City, GeoData, GeoType, BoundedGeoDatum };
+export { City, GeoData, GeoType, BoundingBox, BoundedGeoDatum };


### PR DESCRIPTION
## Description

Addresses: Add toggle between zip / water system geometry

Update parcel config to read public_lead_connections_low_estimate instead of old property
Update geolocate lambda to correctly convert bounding box --> min/max lat,long. Before it was swapping lat and lng, but it worked out because the FE also was. 

Zoom tight into parcels when an address is searched and found. 

## Testing and Reviewing

![image](https://user-images.githubusercontent.com/7783393/187473157-fa57eec9-c689-4662-85fb-cd70af29e155.png)