### PR TITLE
Correctly notify on API monitoring

### DIFF
--- a/cdk/src/open-data-platform/app-plane/api/api-monitoring.ts
+++ b/cdk/src/open-data-platform/app-plane/api/api-monitoring.ts
@@ -23,14 +23,16 @@ export class ApiMonitoring extends Construct {
 
     const availabilitySlo = 0.95;
     const latencyMsSlo = 2000; // Milliseconds
-    const slowBurnPeriod = Duration.days(1);
-    const fastBurnPeriod = Duration.hours(1);
+    const period = Duration.minutes(15);
+    // Alarms will fire if they are above the threshold for the number of periods below.
+    const fastBurnEvalPeriods = 4; // 60 minutes
+    const slowBurnEvalPeriods = 4 * 24; // 24 hours
 
     const alarms = [
       new cloudwatch.MathExpression({
         expression: '(clientError + serverError) / count',
         label: 'Error Fraction',
-        period: slowBurnPeriod,
+        period,
         usingMetrics: {
           clientError: gateway.metricClientError(),
           serverError: gateway.metricServerError(),
@@ -39,15 +41,15 @@ export class ApiMonitoring extends Construct {
       }).createAlarm(scope, 'AvailabilitySLOSlowBurn', {
         alarmDescription: `The API has been running below its ${
           availabilitySlo * 100
-        }% SLO for ${slowBurnPeriod.toString()}.`,
-        evaluationPeriods: 1,
+        }% SLO for ${slowBurnEvalPeriods} x ${period.toString()}.`,
+        evaluationPeriods: slowBurnEvalPeriods,
         threshold: 1 - availabilitySlo,
       }),
 
       new cloudwatch.MathExpression({
         expression: '(clientError + serverError) / count',
         label: 'Error Fraction',
-        period: fastBurnPeriod,
+        period,
         usingMetrics: {
           clientError: gateway.metricClientError(),
           serverError: gateway.metricServerError(),
@@ -56,15 +58,15 @@ export class ApiMonitoring extends Construct {
       }).createAlarm(scope, 'AvailabilitySLOFastBurn', {
         alarmDescription: `The API has been running significantly below its ${
           availabilitySlo * 100
-        }% SLO for ${fastBurnPeriod.toString()}.`,
-        evaluationPeriods: 1,
+        }% SLO for ${fastBurnEvalPeriods} x ${period.toString()}.`,
+        evaluationPeriods: fastBurnEvalPeriods,
         threshold: (1 - availabilitySlo) * 10, // 10x error rate than SLO allows.
       }),
 
       // TODO: This uses average latency. Additionally alert on 95%ile latency over a longer period.
-      gateway.metricLatency({ period: fastBurnPeriod }).createAlarm(scope, 'LatencySLOFastBurn', {
-        alarmDescription: `The API has a higher latency than its ${latencyMsSlo} ms SLO for ${fastBurnPeriod.toString()}.`,
-        evaluationPeriods: 1,
+      gateway.metricLatency({ period }).createAlarm(scope, 'LatencySLOFastBurn', {
+        alarmDescription: `The API has a higher latency than its ${latencyMsSlo} ms SLO for ${fastBurnEvalPeriods} x ${period.toString()}.`,
+        evaluationPeriods: fastBurnEvalPeriods,
         threshold: latencyMsSlo,
       }),
     ];

--- a/cdk/src/open-data-platform/app-plane/api/api-stack.ts
+++ b/cdk/src/open-data-platform/app-plane/api/api-stack.ts
@@ -1,14 +1,19 @@
 import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import { ITopic } from 'aws-cdk-lib/aws-sns';
 import { Construct } from 'constructs';
 import prefixes from '../../frontend/url-prefixes';
 import { AppPlaneStackProps } from '../app-plane-stack';
 import { ApiMonitoring } from './api-monitoring';
 import { apiLambdaFactory } from './lambda-function-factory';
 
+interface ApiStackProps extends AppPlaneStackProps {
+  ticketSNSTopic?: ITopic;
+}
+
 export class ApiStack extends Construct {
   readonly gateway: apigateway.RestApi;
 
-  constructor(scope: Construct, id: string, props: AppPlaneStackProps) {
+  constructor(scope: Construct, id: string, props: ApiStackProps) {
     super(scope, id);
 
     const { dataPlaneStack, networkStack, ticketSNSTopic } = props;

--- a/cdk/src/open-data-platform/app-plane/app-plane-stack.ts
+++ b/cdk/src/open-data-platform/app-plane/app-plane-stack.ts
@@ -7,14 +7,13 @@ import { DataPlaneStack } from '../data-plane/data-plane-stack';
 import { NetworkStack } from '../network/network-stack';
 import { TileServer } from './tileserver/tileserver';
 import { ApiStack } from './api/api-stack';
-import { ITopic } from 'aws-cdk-lib/aws-sns';
+import { Topic } from 'aws-cdk-lib/aws-sns';
 
 // TODO: consider narrowing the props down to the specific things that the App Plane needs.
 // E.g. just the cluster object itself, rather than the entire network stack.
 export interface AppPlaneStackProps extends CommonProps {
   networkStack: NetworkStack;
   dataPlaneStack: DataPlaneStack;
-  ticketSNSTopic?: ITopic;
 }
 
 export class AppPlaneStack extends Stack {
@@ -24,7 +23,7 @@ export class AppPlaneStack extends Stack {
   constructor(scope: Construct, id: string, props: AppPlaneStackProps) {
     super(scope, id, props);
 
-    const { networkStack, dataPlaneStack } = props;
+    const { networkStack, dataPlaneStack, ticketSNSTopicArn } = props;
 
     this.tileServer = new TileServer(this, 'TileServer', {
       ecsCluster: networkStack.cluster,
@@ -32,6 +31,11 @@ export class AppPlaneStack extends Stack {
       databaseUrlSecret: dataPlaneStack.tileserverCredentials.databaseUrlSecret,
     });
 
-    this.api = new ApiStack(this, 'ApiStack', props);
+    this.api = new ApiStack(this, 'ApiStack', {
+      ...props,
+      ticketSNSTopic: ticketSNSTopicArn
+        ? Topic.fromTopicArn(this, 'ticketSNSTopic', ticketSNSTopicArn)
+        : undefined,
+    });
   }
 }


### PR DESCRIPTION
## Description

https://github.com/BlueConduit/open-data-platform/pull/144 added monitoring, but didn't correctly pass the SNS Topic down the stack. This fixes that.

I missed this problem because I didn't check that the alarms actually sent anything to Slack. And the optional type still let it compile.

### Changed

- Create the notification Topic from the ARN and pass it down the stack.
- Split alarms into multiple evaluation periods. This doesn't change the alarm itself, but makes the graphs more granular.

## Testing and Reviewing

My [alarms](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#alarmsV2:alarm/beekley-OpenDataPlatformAppPlane-ApiStackAvailabilitySLOSlowBurn70D70F36-1NMZZJY6RA9A3?~(search~'beekley)) have notifications now:

![image](https://user-images.githubusercontent.com/4321880/187508905-603c3713-8e74-43b3-9f5c-d61f480e98e1.png)
