### PR TITLE
UI fixes

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -17,7 +17,7 @@ import { dispatch, useSelector } from './model/store';
 import { GEOTYPE_PARAM, LAT_LONG_PARAM, LAYER_PARAM } from './router';
 import { GeoType } from './model/states/model/geo_data';
 import PageFooter from './components/PageFooter.vue';
-import { setCurrentDataLayer } from './model/slices/map_data_slice';
+import { clearMapData, setCurrentDataLayer } from './model/slices/map_data_slice';
 import { MapDataState } from './model/states/map_data_state';
 import { MapLayer } from './model/data_layer';
 import { clearLeadData } from './model/slices/lead_data_slice';
@@ -59,6 +59,7 @@ export default defineComponent({
         dispatch(clearGeoIds());
         dispatch(clearLeadData());
         dispatch(clearDemographicData());
+        dispatch(clearMapData());
       }
 
       // Check whether router has a param with the layer to show on the map.

--- a/client/src/assets/styles/global.scss
+++ b/client/src/assets/styles/global.scss
@@ -6,6 +6,7 @@
 /** Colors */
 /** TODO: Move colors to copper.*/
 $light-grey: #A3A3A3;
+$warm-grey-100: #F6F6F6;
 $warm-grey-600: #757575;
 $warm-grey-800: #464646;
 $warm-grey-900: #212121;

--- a/client/src/components/NationwideMap.vue
+++ b/client/src/components/NationwideMap.vue
@@ -173,7 +173,8 @@ export default defineComponent({
       const sw = new mapboxgl.LngLat(bounds.minLon, bounds.minLat);
       const ne = new mapboxgl.LngLat(bounds.maxLon, bounds.maxLat);
 
-      this.map?.fitBounds(new LngLatBounds(sw, ne));
+      // Do not animate on fitBounds on the scorecard page.
+      this.map?.fitBounds(new LngLatBounds(sw, ne), { animate: !this.scorecard });
     },
 
     /**

--- a/client/src/components/NationwideMap.vue
+++ b/client/src/components/NationwideMap.vue
@@ -342,8 +342,10 @@ export default defineComponent({
       // Add geolocate control to the map.
       this.map.addControl(geolocateControl);
 
-      // Add zoom in / zoom out buttons to map.
-      this.map.addControl(new mapboxgl.NavigationControl());
+      // Add zoom in / zoom out buttons to Nationwide Map view.
+      if (!this.scorecard) {
+        this.map.addControl(new mapboxgl.NavigationControl());
+      }
     },
 
     /**
@@ -447,7 +449,6 @@ export default defineComponent({
         if (newDataLayerId == null) {
           return;
         }
-        // TODO: maybe remove this check after testing?
         if (this.map?.isStyleLoaded()) {
           this.updateMapOnDataLayerChange(ALL_DATA_LAYERS.get(newDataLayerId));
         }

--- a/client/src/components/NationwideMap.vue
+++ b/client/src/components/NationwideMap.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script lang='ts'>
-import mapboxgl, { LngLatBounds, LngLatLike, MapLayerMouseEvent } from 'mapbox-gl';
+import mapboxgl, { LngLatLike, LngLatBounds, MapLayerMouseEvent } from 'mapbox-gl';
 import MapLegend from './MapLegend.vue';
 import MapPopupContent from './MapPopupContent.vue';
 import { createApp, defineComponent, nextTick, PropType } from 'vue';
@@ -15,7 +15,8 @@ import { MAP_ROUTE_BASE, router, SCORECARD_BASE } from '../router';
 import { dispatch, useSelector } from '../model/store';
 import { GeoDataState } from '../model/states/geo_data_state';
 import { MapDataState } from '../model/states/map_data_state';
-import { ALL_DATA_LAYERS, setCurrentDataLayer, setZoom } from '../model/slices/map_data_slice';
+import { ALL_DATA_LAYERS, setCurrentDataLayer, setScorecardZoom, setZoom } from '../model/slices/map_data_slice';
+import { ScorecardZoomLevel } from '../model/states/model/map_data';
 import { GeoType } from '../model/states/model/geo_data';
 
 const DEFAULT_LNG_LAT = [-98.5556199, 39.8097343];
@@ -152,7 +153,7 @@ export default defineComponent({
           waterSystemBoundingBox.maxLat,
         );
 
-        this.map?.fitBounds(new LngLatBounds(sw, ne));
+        dispatch(setScorecardZoom(ScorecardZoomLevel.waterSystem, waterSystemBoundingBox));
 
         // When there are no bounding boxes available, go to zipcode.
       } else {
@@ -409,6 +410,17 @@ export default defineComponent({
         }
         this.updateMapOnDataLayerChange(ALL_DATA_LAYERS.get(newDataLayerId));
       },
+    },
+    'mapState.mapData.scorecardZoom': function() {
+      const bounds = this.mapState?.mapData?.scorecardZoom?.bounds;
+      // const level = this.mapState?.mapData?.scorecardZoom?.level;
+
+      if (bounds) {
+        const sw = new mapboxgl.LngLat(bounds.minLon, bounds.minLat);
+        const ne = new mapboxgl.LngLat(bounds.maxLon, bounds.maxLat);
+
+        this.map?.fitBounds(new LngLatBounds(sw, ne));
+      }
     },
     // Listen for changes to lat/long to update map location.
     'geoState.geoids': function() {

--- a/client/src/components/PredictionPanel.vue
+++ b/client/src/components/PredictionPanel.vue
@@ -51,6 +51,7 @@ import { LeadDataState } from '../model/states/lead_data_state';
 import { BoundedGeoDatum, GeoType } from '../model/states/model/geo_data';
 import { Status } from '../model/states/status_state';
 import { clearDemographicData } from '../model/slices/demographic_data_slice';
+import { GeoDataUtil } from '../util/geo_data_util';
 
 const LOW_LEAD_LIKELIHOOD = 0.33;
 const MEDIUM_LEAD_LIKELIHOOD = 0.66;
@@ -109,10 +110,7 @@ export default defineComponent({
     // True if and only if there is no current search criteria. This will be false if there is a
     // search but there is no prediction data for that search.
     emptyGeoData(): boolean {
-      return this.geoState?.geoids?.geoType == null
-        && this.geoState?.geoids?.pwsId == null
-        && this.geoState?.geoids?.address == null
-        && this.geoState?.geoids?.zipCode == null;
+      return GeoDataUtil.isNullOrEmpty(this.geoState?.geoids);
     },
     showParcelPrediction(): boolean {
       return this.geoState?.geoids?.geoType == GeoType.address && this.publicLeadLikelihood != null;

--- a/client/src/components/ScorecardMapSearchBar.vue
+++ b/client/src/components/ScorecardMapSearchBar.vue
@@ -8,11 +8,10 @@
         :selected='getSelected(option)'
         @click='setSelected(option)' />
     </div>
-    <div class='search-wrapper'>
-      <map-geocoder-wrapper class='search'
-                            :baseUrl='SCORECARD_BASE'
-                            :expandSearch='true' />
-    </div>
+    <map-geocoder-wrapper
+      :acceptedTypes='acceptedTypes'
+      :baseUrl='SCORECARD_BASE'
+      v-model:expandSearch='showSearch' />
   </div>
 </template>
 
@@ -27,6 +26,7 @@ import { GeoDataState } from '../model/states/geo_data_state';
 import { MapDataState } from '../model/states/map_data_state';
 import { ZoomLevel } from '../model/states/model/map_data';
 import { setZoomLevel } from '../model/slices/map_data_slice';
+import { GeoType } from '../model/states/model/geo_data';
 
 /**
  * The zoom and search bar for the scorecard map.
@@ -50,8 +50,10 @@ export default defineComponent({
   },
   data() {
     return {
+      acceptedTypes: [GeoType.address, GeoType.postcode],
       options: [] as ZoomLevel[],
       selectedOption: null as ZoomLevel | null,
+      showSearch: true,
       SCORECARD_BASE,
     };
   },
@@ -102,23 +104,17 @@ export default defineComponent({
 });
 </script>
 
-<style scoped>
-.search {
-  display: flex;
-}
+<style scoped lang='scss'>
+@import '../assets/styles/global.scss';
+@import '@blueconduit/copper/scss/01_settings/design-tokens';
 
 .searchbar-container {
   display: flex;
-  height: 54px;
-  padding: 0 15px;
   align-items: center;
   justify-content: space-between;
-  background-color: #F6F6F6; /* TODO use global css vars for this. */
-}
-
-.search-wrapper {
-  display: flex;
-  padding-left: 15px;
+  height: $spacing-xl;
+  padding: 0 $spacing-md;
+  background-color: $warm-grey-100;
 }
 
 .zoom-options {

--- a/client/src/components/ScorecardMapSearchBar.vue
+++ b/client/src/components/ScorecardMapSearchBar.vue
@@ -1,5 +1,6 @@
 <template>
   <div class='searchbar-container'>
+    <p v-if='options.length > 0'>View by:</p>
     <div class='zoom-options'>
       <search-bar-option
         v-for='option in options'
@@ -8,6 +9,7 @@
         :selected='getSelected(option)'
         @click='setSelected(option)' />
     </div>
+    <!--    TODO add more descriptive placeholder.-->
     <map-geocoder-wrapper
       :acceptedTypes='acceptedTypes'
       :baseUrl='SCORECARD_BASE'

--- a/client/src/components/ScorecardMapSearchBar.vue
+++ b/client/src/components/ScorecardMapSearchBar.vue
@@ -20,7 +20,6 @@ import { defineComponent } from 'vue';
 import { SCORECARD_BASE } from '../router';
 import SearchBarOption from './SearchBarOption.vue';
 import MapGeocoderWrapper from './MapGeocoderWrapper.vue';
-import mapboxgl from 'mapbox-gl';
 import { dispatch, useSelector } from '../model/store';
 import { GeoDataState } from '../model/states/geo_data_state';
 import { MapDataState } from '../model/states/map_data_state';
@@ -38,8 +37,6 @@ export default defineComponent({
     SearchBarOption,
   },
   setup() {
-    mapboxgl.accessToken = process.env.VUE_APP_MAP_BOX_API_TOKEN ?? '';
-
     const geoState = useSelector((state) => state.geos) as GeoDataState;
     const mapState = useSelector((state) => state.mapData) as MapDataState;
 

--- a/client/src/components/ScorecardMapZoomBar.vue
+++ b/client/src/components/ScorecardMapZoomBar.vue
@@ -25,8 +25,8 @@ import mapboxgl from 'mapbox-gl';
 import { dispatch, useSelector } from '../model/store';
 import { GeoDataState } from '../model/states/geo_data_state';
 import { MapDataState } from '../model/states/map_data_state';
-import { ScorecardZoomLevel } from '../model/states/model/map_data';
-import { setScorecardZoomLevel } from '../model/slices/map_data_slice';
+import { ZoomLevel } from '../model/states/model/map_data';
+import { setZoomLevel } from '../model/slices/map_data_slice';
 
 /**
  * The zoom and search bar for the scorecard map.
@@ -40,7 +40,6 @@ export default defineComponent({
   setup() {
     mapboxgl.accessToken = process.env.VUE_APP_MAP_BOX_API_TOKEN ?? '';
 
-    // Listen to geoState updates.
     const geoState = useSelector((state) => state.geos) as GeoDataState;
     const mapState = useSelector((state) => state.mapData) as MapDataState;
 
@@ -51,8 +50,8 @@ export default defineComponent({
   },
   data() {
     return {
-      options: [] as ScorecardZoomLevel[],
-      selectedOption: null as ScorecardZoomLevel | null,
+      options: [] as ZoomLevel[],
+      selectedOption: null as ZoomLevel | null,
       SCORECARD_BASE,
     };
   },
@@ -62,7 +61,7 @@ export default defineComponent({
      *
      * @param option
      */
-    getSelected(option: ScorecardZoomLevel): boolean {
+    getSelected(option: ZoomLevel): boolean {
       return option === this.selectedOption;
     },
 
@@ -71,8 +70,8 @@ export default defineComponent({
      *
      * @param option
      */
-    setSelected(option: ScorecardZoomLevel): void {
-      dispatch(setScorecardZoomLevel(option));
+    setSelected(option: ZoomLevel): void {
+      dispatch(setZoomLevel(option));
     },
 
     /**
@@ -82,19 +81,19 @@ export default defineComponent({
       const geoIds = this.geoState?.geoids;
       this.options = [];
       if (geoIds?.address?.id) {
-        this.options.push(ScorecardZoomLevel.address);
+        this.options.push(ZoomLevel.address);
       }
       if (geoIds?.pwsId?.id) {
-        this.options.push(ScorecardZoomLevel.waterSystem);
+        this.options.push(ZoomLevel.waterSystem);
       }
       if (geoIds?.zipCode?.id) {
-        this.options.push(ScorecardZoomLevel.zipCode);
+        this.options.push(ZoomLevel.zipCode);
       }
     },
   },
   watch: {
-    'mapState.mapData.scorecardZoom': function() {
-      this.selectedOption = this.mapState?.mapData?.scorecardZoom?.level ?? null;
+    'mapState.mapData.zoomLevel': function() {
+      this.selectedOption = this.mapState?.mapData?.zoomLevel ?? null;
     },
     'geoState.geoids': function() {
       this.setOptions();

--- a/client/src/components/ScorecardMapZoomBar.vue
+++ b/client/src/components/ScorecardMapZoomBar.vue
@@ -27,8 +27,10 @@ import { GeoDataState } from '../model/states/geo_data_state';
 import { MapDataState } from '../model/states/map_data_state';
 import { ScorecardZoomLevel } from '../model/states/model/map_data';
 import { setScorecardZoomLevel } from '../model/slices/map_data_slice';
-import { BoundingBox } from '../model/states/model/geo_data';
 
+/**
+ * The zoom and search bar for the scorecard map.
+ */
 export default defineComponent({
   name: 'ScorecardMapZoomBar',
   components: {
@@ -72,25 +74,30 @@ export default defineComponent({
     setSelected(option: ScorecardZoomLevel): void {
       dispatch(setScorecardZoomLevel(option));
     },
+
+    /**
+     * Sets zoom level options based on the present geo IDs.
+     */
+    setOptions() {
+      const geoIds = this.geoState?.geoids;
+      this.options = [];
+      if (geoIds?.address?.id) {
+        this.options.push(ScorecardZoomLevel.address);
+      }
+      if (geoIds?.pwsId?.id) {
+        this.options.push(ScorecardZoomLevel.waterSystem);
+      }
+      if (geoIds?.zipCode?.id) {
+        this.options.push(ScorecardZoomLevel.zipCode);
+      }
+    },
   },
   watch: {
     'mapState.mapData.scorecardZoom': function() {
-      console.log('SETTING SELECTED: ' + this.selectedOption);
       this.selectedOption = this.mapState?.mapData?.scorecardZoom?.level ?? null;
     },
     'geoState.geoids': function() {
-      const geoIds = this.geoState?.geoids;
-      const options = [];
-      if (geoIds?.address?.id) {
-        options.push(ScorecardZoomLevel.address);
-      }
-      if (geoIds?.pwsId?.id) {
-        options.push(ScorecardZoomLevel.waterSystem);
-      }
-      if (geoIds?.zipCode?.id) {
-        options.push(ScorecardZoomLevel.zipCode);
-      }
-      this.options = options;
+      this.setOptions();
     },
   },
 });

--- a/client/src/components/ScorecardMapZoomBar.vue
+++ b/client/src/components/ScorecardMapZoomBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class='searchbar-container' v-if='options.length > 0'>
+  <div class='searchbar-container'>
     <div class='zoom-options'>
       <search-bar-option
         v-for='option in options'
@@ -95,6 +95,9 @@ export default defineComponent({
     'geoState.geoids': function() {
       const geoIds = this.geoState?.geoids;
       const options = [];
+      if (geoIds?.address) {
+        options.push(ScorecardZoomLevel.address);
+      }
       if (geoIds?.pwsId) {
         options.push(ScorecardZoomLevel.waterSystem);
       }

--- a/client/src/components/ScorecardMapZoomBar.vue
+++ b/client/src/components/ScorecardMapZoomBar.vue
@@ -26,7 +26,7 @@ import { dispatch, useSelector } from '../model/store';
 import { GeoDataState } from '../model/states/geo_data_state';
 import { MapDataState } from '../model/states/map_data_state';
 import { ScorecardZoomLevel } from '../model/states/model/map_data';
-import { setScorecardZoom } from '../model/slices/map_data_slice';
+import { setScorecardZoomLevel } from '../model/slices/map_data_slice';
 import { BoundingBox } from '../model/states/model/geo_data';
 
 export default defineComponent({
@@ -70,21 +70,7 @@ export default defineComponent({
      * @param option
      */
     setSelected(option: ScorecardZoomLevel): void {
-      this.selectedOption = option;
-      const bounds = this.getBounds(option);
-      if (bounds) {
-        dispatch(setScorecardZoom(option, bounds));
-      }
-    },
-
-    getBounds(level: ScorecardZoomLevel): BoundingBox | null {
-      if (level == ScorecardZoomLevel.waterSystem) {
-        return this.geoState?.geoids?.pwsId?.boundingBox ?? null;
-      }
-      if (level == ScorecardZoomLevel.zipCode) {
-        return this.geoState?.geoids?.zipCode?.boundingBox ?? null;
-      }
-      return null;
+      dispatch(setScorecardZoomLevel(option));
     },
   },
   watch: {

--- a/client/src/components/ScorecardMapZoomBar.vue
+++ b/client/src/components/ScorecardMapZoomBar.vue
@@ -95,13 +95,13 @@ export default defineComponent({
     'geoState.geoids': function() {
       const geoIds = this.geoState?.geoids;
       const options = [];
-      if (geoIds?.address) {
+      if (geoIds?.address?.id) {
         options.push(ScorecardZoomLevel.address);
       }
-      if (geoIds?.pwsId) {
+      if (geoIds?.pwsId?.id) {
         options.push(ScorecardZoomLevel.waterSystem);
       }
-      if (geoIds?.zipCode) {
+      if (geoIds?.zipCode?.id) {
         options.push(ScorecardZoomLevel.zipCode);
       }
       this.options = options;

--- a/client/src/components/ScorecardMapZoomBar.vue
+++ b/client/src/components/ScorecardMapZoomBar.vue
@@ -1,0 +1,135 @@
+<template>
+  <div class='searchbar-container' v-if='options.length > 0'>
+    <div class='zoom-options'>
+      <search-bar-option
+        v-for='option in options'
+        :key='option'
+        :text-content='option'
+        :selected='getSelected(option)'
+        @click='setSelected(option)' />
+    </div>
+    <div class='search-wrapper'>
+      <map-geocoder-wrapper class='search'
+                            :baseUrl='SCORECARD_BASE'
+                            :expandSearch='true' />
+    </div>
+  </div>
+</template>
+
+<script lang='ts'>
+import { defineComponent } from 'vue';
+import { SCORECARD_BASE } from '../router';
+import SearchBarOption from './SearchBarOption.vue';
+import MapGeocoderWrapper from './MapGeocoderWrapper.vue';
+import mapboxgl from 'mapbox-gl';
+import { dispatch, useSelector } from '../model/store';
+import { GeoDataState } from '../model/states/geo_data_state';
+import { MapDataState } from '../model/states/map_data_state';
+import { ScorecardZoomLevel } from '../model/states/model/map_data';
+import { setScorecardZoom } from '../model/slices/map_data_slice';
+import { BoundingBox } from '../model/states/model/geo_data';
+
+export default defineComponent({
+  name: 'ScorecardMapZoomBar',
+  components: {
+    MapGeocoderWrapper,
+    SearchBarOption,
+  },
+  setup() {
+    mapboxgl.accessToken = process.env.VUE_APP_MAP_BOX_API_TOKEN ?? '';
+
+    // Listen to geoState updates.
+    const geoState = useSelector((state) => state.geos) as GeoDataState;
+    const mapState = useSelector((state) => state.mapData) as MapDataState;
+
+    return {
+      geoState,
+      mapState,
+    };
+  },
+  data() {
+    return {
+      options: [] as ScorecardZoomLevel[],
+      selectedOption: null as ScorecardZoomLevel | null,
+      SCORECARD_BASE,
+    };
+  },
+  methods: {
+    /**
+     * Returns whether {@code option} is the selected option.
+     *
+     * @param option
+     */
+    getSelected(option: ScorecardZoomLevel): boolean {
+      return option === this.selectedOption;
+    },
+
+    /**
+     * Updates the selected option to {@code option} from a click on an option button.
+     *
+     * @param option
+     */
+    setSelected(option: ScorecardZoomLevel): void {
+      this.selectedOption = option;
+      const bounds = this.getBounds(option);
+      if (bounds) {
+        dispatch(setScorecardZoom(option, bounds));
+      }
+    },
+
+    getBounds(level: ScorecardZoomLevel): BoundingBox | null {
+      if (level == ScorecardZoomLevel.waterSystem) {
+        return this.geoState?.geoids?.pwsId?.boundingBox ?? null;
+      }
+      if (level == ScorecardZoomLevel.zipCode) {
+        return this.geoState?.geoids?.zipCode?.boundingBox ?? null;
+      }
+      return null;
+    },
+  },
+  watch: {
+    'mapState.mapData.scorecardZoom': function() {
+      console.log('SETTING SELECTED: ' + this.selectedOption);
+      this.selectedOption = this.mapState?.mapData?.scorecardZoom?.level ?? null;
+    },
+    'geoState.geoids': function() {
+      const geoIds = this.geoState?.geoids;
+      const options = [];
+      if (geoIds?.pwsId) {
+        options.push(ScorecardZoomLevel.waterSystem);
+      }
+      if (geoIds?.zipCode) {
+        options.push(ScorecardZoomLevel.zipCode);
+      }
+      this.options = options;
+    },
+  },
+});
+</script>
+
+<style scoped>
+.search {
+  display: flex;
+}
+
+.searchbar-container {
+  display: flex;
+  height: 54px;
+  padding: 0 15px;
+  align-items: center;
+  justify-content: space-between;
+  background-color: #F6F6F6; /* TODO use global css vars for this. */
+}
+
+.search-wrapper {
+  display: flex;
+  padding-left: 15px;
+}
+
+.zoom-options {
+  display: flex;
+  align-items: center;
+  flex-grow: 1;
+  min-width: fit-content;
+}
+</style>

--- a/client/src/model/slices/map_data_slice.ts
+++ b/client/src/model/slices/map_data_slice.ts
@@ -2,12 +2,14 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { AppDispatch } from '@/model/store';
 import { Status } from '@/model/states/status_state';
 import { MapDataState } from '@/model/states/map_data_state';
-import { MapData } from '@/model/states/model/map_data';
+import { MapData, ScorecardZoomLevel } from '@/model/states/model/map_data';
 import { DataLayer, MapLayer } from '@/model/data_layer';
 import { leadServiceLinesByWaterSystemLayer } from '@/data_layer_configs/lead_service_lines_by_water_systems_config';
 import { leadAndCopperViolationsByCountyDataLayer } from '@/data_layer_configs/lead_and_copper_violations_by_water_system_config';
 import { populationDataByCensusBlockLayer } from '@/data_layer_configs/population_by_census_block_config';
 import { leadServiceLinesByParcelLayer } from '@/data_layer_configs/lead_service_lines_by_parcel_config';
+import { BoundingBox } from '@/model/states/model/geo_data';
+import { leadDataCleared } from '@/model/slices/lead_data_slice';
 
 export const ALL_DATA_LAYERS = new Map<MapLayer, DataLayer>([
   [MapLayer.LeadServiceLineByWaterSystem, leadServiceLinesByWaterSystemLayer],
@@ -24,7 +26,7 @@ const mapSlice = createSlice({
   name: 'mapSlice',
   initialState,
   reducers: {
-    setCurrentDataLayerSuccess: (state: MapDataState, action: PayloadAction<MapData>) => {
+    setMapDataSuccess: (state: MapDataState, action: PayloadAction<MapData>) => {
       console.log(`Successfully updated map : ${JSON.stringify(state)} ${JSON.stringify(action)}`);
 
       return {
@@ -33,17 +35,16 @@ const mapSlice = createSlice({
         status: { status: Status.success },
       };
     },
-    setCurrentDataLayerError: (state: MapDataState, action: PayloadAction<any>) => {
+    setMapDataError: (state: MapDataState, action: PayloadAction<any>) => {
       console.log(`Error updating map : ${JSON.stringify(state)} ${JSON.stringify(action)}`);
       state.status = {
         status: Status.error,
         message: action.payload.error,
       };
     },
-    setZoom: (state: MapDataState, action: PayloadAction<MapData>) => {
+    mapDataCleared: () => {
       return {
-        ...state,
-        mapData: { ...state.mapData, ...action.payload },
+        data: {},
         status: { status: Status.success },
       };
     },
@@ -56,9 +57,9 @@ const mapSlice = createSlice({
 export const setCurrentDataLayer = (layerId: string) => {
   return async (dispatch: AppDispatch) => {
     if (layerId == null) {
-      dispatch(setCurrentDataLayerError({ error: 'Invalid map state' }));
+      dispatch(setMapDataError({ error: 'Invalid map state' }));
     } else {
-      dispatch(setCurrentDataLayerSuccess({ currentDataLayerId: layerId as MapLayer }));
+      dispatch(setMapDataSuccess({ currentDataLayerId: layerId as MapLayer }));
     }
   };
 };
@@ -69,14 +70,36 @@ export const setCurrentDataLayer = (layerId: string) => {
 export const setZoom = (zoom: number) => {
   return async (dispatch: AppDispatch) => {
     if (zoom == null) {
-      dispatch(setCurrentDataLayerError({ error: 'Invalid zoom' }));
+      dispatch(setMapDataError({ error: 'Invalid zoom' }));
     } else {
-      dispatch(setCurrentDataLayerSuccess({ zoom: zoom }));
+      dispatch(setMapDataSuccess({ zoom: zoom }));
     }
+  };
+};
+
+export const setScorecardZoom = (level: ScorecardZoomLevel, bounds: BoundingBox) => {
+  return async (dispatch: AppDispatch) => {
+    dispatch(
+      setMapDataSuccess({
+        scorecardZoom: {
+          level: level,
+          bounds: bounds,
+        },
+      }),
+    );
+  };
+};
+
+/**
+ * Clears MapDataState.
+ */
+export const clearMapData = () => {
+  return async (dispatch: AppDispatch) => {
+    dispatch(mapDataCleared());
   };
 };
 
 // See more about reducers:
 // https://redux-toolkit.js.org/api/createslice#reducers
-export const { setCurrentDataLayerSuccess, setCurrentDataLayerError } = mapSlice.actions;
+export const { mapDataCleared, setMapDataSuccess, setMapDataError } = mapSlice.actions;
 export default mapSlice.reducer;

--- a/client/src/model/slices/map_data_slice.ts
+++ b/client/src/model/slices/map_data_slice.ts
@@ -2,14 +2,12 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { AppDispatch } from '@/model/store';
 import { Status } from '@/model/states/status_state';
 import { MapDataState } from '@/model/states/map_data_state';
-import { MapData, ScorecardZoomLevel } from '@/model/states/model/map_data';
+import { MapData, ZoomLevel } from '@/model/states/model/map_data';
 import { DataLayer, MapLayer } from '@/model/data_layer';
 import { leadServiceLinesByWaterSystemLayer } from '@/data_layer_configs/lead_service_lines_by_water_systems_config';
 import { leadAndCopperViolationsByCountyDataLayer } from '@/data_layer_configs/lead_and_copper_violations_by_water_system_config';
 import { populationDataByCensusBlockLayer } from '@/data_layer_configs/population_by_census_block_config';
 import { leadServiceLinesByParcelLayer } from '@/data_layer_configs/lead_service_lines_by_parcel_config';
-import { BoundingBox } from '@/model/states/model/geo_data';
-import { leadDataCleared } from '@/model/slices/lead_data_slice';
 
 export const ALL_DATA_LAYERS = new Map<MapLayer, DataLayer>([
   [MapLayer.LeadServiceLineByWaterSystem, leadServiceLinesByWaterSystemLayer],
@@ -77,13 +75,11 @@ export const setZoom = (zoom: number) => {
   };
 };
 
-export const setScorecardZoomLevel = (level: ScorecardZoomLevel) => {
+export const setZoomLevel = (level: ZoomLevel) => {
   return async (dispatch: AppDispatch) => {
     dispatch(
       setMapDataSuccess({
-        scorecardZoom: {
-          level: level,
-        },
+        zoomLevel: level,
       }),
     );
   };

--- a/client/src/model/slices/map_data_slice.ts
+++ b/client/src/model/slices/map_data_slice.ts
@@ -63,7 +63,7 @@ export const setCurrentDataLayer = (layerId: string) => {
 };
 
 /**
- * Change the zoom level.
+ * Update the integer zoom level.
  */
 export const setZoom = (zoom: number) => {
   return async (dispatch: AppDispatch) => {
@@ -75,6 +75,9 @@ export const setZoom = (zoom: number) => {
   };
 };
 
+/**
+ * Change the zoom to either an address, water system, or zip code level.
+ */
 export const setZoomLevel = (level: ZoomLevel) => {
   return async (dispatch: AppDispatch) => {
     dispatch(

--- a/client/src/model/slices/map_data_slice.ts
+++ b/client/src/model/slices/map_data_slice.ts
@@ -77,13 +77,12 @@ export const setZoom = (zoom: number) => {
   };
 };
 
-export const setScorecardZoom = (level: ScorecardZoomLevel, bounds: BoundingBox) => {
+export const setScorecardZoomLevel = (level: ScorecardZoomLevel) => {
   return async (dispatch: AppDispatch) => {
     dispatch(
       setMapDataSuccess({
         scorecardZoom: {
           level: level,
-          bounds: bounds,
         },
       }),
     );

--- a/client/src/model/slices/map_data_slice.ts
+++ b/client/src/model/slices/map_data_slice.ts
@@ -79,7 +79,7 @@ export const setZoom = (zoom: number) => {
  * Change the zoom to either an address, water system, or zip code level.
  */
 export const setZoomLevel = (level: ZoomLevel) => {
-  return async (dispatch: AppDispatch) => {
+  return (dispatch: AppDispatch) => {
     dispatch(
       setMapDataSuccess({
         zoomLevel: level,

--- a/client/src/model/states/model/map_data.ts
+++ b/client/src/model/states/model/map_data.ts
@@ -4,6 +4,7 @@
 
 import { MapLayer } from '@/model/data_layer';
 import { BoundingBox } from '@/model/states/model/geo_data';
+import { LngLatLike } from 'mapbox-gl';
 
 /**
  * Model for geo id selection.
@@ -12,18 +13,21 @@ interface MapData {
   currentDataLayerId?: MapLayer;
   dataLayers?: MapLayer[];
   zoom?: number;
+  center?: LngLatLike;
   scorecardZoom?: ScorecardZoomInfo;
 }
 
+// TODO: remove this middle object and put all in mapdata.
 interface ScorecardZoomInfo {
   level: ScorecardZoomLevel;
-  bounds: BoundingBox;
+  bounds?: BoundingBox;
 }
 
 enum ScorecardZoomLevel {
   address = 'Address',
   waterSystem = 'Water system',
   zipCode = 'Zip code',
+  unknown = 'Unknown',
 }
 
 export { MapData, ScorecardZoomInfo, ScorecardZoomLevel };

--- a/client/src/model/states/model/map_data.ts
+++ b/client/src/model/states/model/map_data.ts
@@ -3,6 +3,7 @@
  */
 
 import { MapLayer } from '@/model/data_layer';
+import { BoundingBox } from '@/model/states/model/geo_data';
 
 /**
  * Model for geo id selection.
@@ -11,6 +12,17 @@ interface MapData {
   currentDataLayerId?: MapLayer;
   dataLayers?: MapLayer[];
   zoom?: number;
+  scorecardZoom?: ScorecardZoomInfo;
 }
 
-export { MapData };
+interface ScorecardZoomInfo {
+  level: ScorecardZoomLevel;
+  bounds: BoundingBox;
+}
+
+enum ScorecardZoomLevel {
+  waterSystem = 'Water system',
+  zipCode = 'Zip code',
+}
+
+export { MapData, ScorecardZoomInfo, ScorecardZoomLevel };

--- a/client/src/model/states/model/map_data.ts
+++ b/client/src/model/states/model/map_data.ts
@@ -21,6 +21,7 @@ interface ScorecardZoomInfo {
 }
 
 enum ScorecardZoomLevel {
+  address = 'Address',
   waterSystem = 'Water system',
   zipCode = 'Zip code',
 }

--- a/client/src/model/states/model/map_data.ts
+++ b/client/src/model/states/model/map_data.ts
@@ -3,7 +3,6 @@
  */
 
 import { MapLayer } from '@/model/data_layer';
-import { BoundingBox } from '@/model/states/model/geo_data';
 import { LngLatLike } from 'mapbox-gl';
 
 /**
@@ -14,20 +13,14 @@ interface MapData {
   dataLayers?: MapLayer[];
   zoom?: number;
   center?: LngLatLike;
-  scorecardZoom?: ScorecardZoomInfo;
+  zoomLevel?: ZoomLevel;
 }
 
-// TODO: remove this middle object and put all in mapdata.
-interface ScorecardZoomInfo {
-  level: ScorecardZoomLevel;
-  bounds?: BoundingBox;
-}
-
-enum ScorecardZoomLevel {
+enum ZoomLevel {
   address = 'Address',
   waterSystem = 'Water system',
   zipCode = 'Zip code',
   unknown = 'Unknown',
 }
 
-export { MapData, ScorecardZoomInfo, ScorecardZoomLevel };
+export { MapData, ZoomLevel };

--- a/client/src/util/geo_data_util.ts
+++ b/client/src/util/geo_data_util.ts
@@ -1,0 +1,18 @@
+import { GeoData } from '@/model/states/model/geo_data';
+
+/**
+ * Utility functions for the GeoData type.
+ */
+export class GeoDataUtil {
+  static isNullOrEmpty(geoData: GeoData | undefined) {
+    return (
+      geoData == null ||
+      (geoData.geoType == null &&
+        geoData.pwsId == null &&
+        geoData.address == null &&
+        geoData.zipCode == null &&
+        geoData.lat == null &&
+        geoData.long == null)
+    );
+  }
+}

--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -2,12 +2,13 @@
   <div>
     <PredictionPanel />
     <div class='map-container'>
-      <MapGeocoderWrapper
-        class='search'
-        :acceptedTypes='acceptedTypes'
-        :baseUrl='SCORECARD_BASE'
-        v-model:expandSearch='showSearch'
-      />
+      <!--      <MapGeocoderWrapper-->
+      <!--        class='search'-->
+      <!--        :acceptedTypes='acceptedTypes'-->
+      <!--        :baseUrl='SCORECARD_BASE'-->
+      <!--        v-model:expandSearch='showSearch'-->
+      <!--      />-->
+      <ScorecardMapZoomBar />
       <NationwideMap height='60vh' :scorecard='true' />
     </div>
     <div class='container-column center-container actions-to-take'
@@ -41,7 +42,7 @@
   </div>
 </template>
 
-<script lang="ts">
+<script lang='ts'>
 import PredictionPanel from '../components/PredictionPanel.vue';
 import ActionSection from '../components/ActionSection.vue';
 import { defineComponent } from 'vue';
@@ -57,6 +58,8 @@ import { City, GeoType } from '../model/states/model/geo_data';
 import MapGeocoderWrapper from '../components/MapGeocoderWrapper.vue';
 import { GeoDataState } from '../model/states/geo_data_state';
 import { GeoDataUtil } from '../util/geo_data_util';
+import SearchBar from '../components/SearchBar.vue';
+import ScorecardMapZoomBar from '../components/ScorecardMapZoomBar.vue';
 
 /**
  * Container for SearchBar and MapContainer.
@@ -66,10 +69,12 @@ export default defineComponent({
   components: {
     ActionSection,
     LslrSection,
-    MapGeocoderWrapper,
+    // MapGeocoderWrapper,
     NationwideMap,
     PredictionPanel,
     ScorecardSummaryPanel,
+    // SearchBar,
+    ScorecardMapZoomBar,
   },
   setup() {
     const geoState = useSelector((state) => state.geos) as GeoDataState;
@@ -108,7 +113,7 @@ export default defineComponent({
     },
   },
   watch: {
-    'leadDataState.data.city': function () {
+    'leadDataState.data.city': function() {
       const city = this.leadDataState?.data?.city ?? City.unknown;
       this.showLslr = city != null && LSLR_CITY_LINKS.get(city) != null;
     },
@@ -119,7 +124,7 @@ export default defineComponent({
 });
 </script>
 
-<style scoped lang="scss">
+<style scoped lang='scss'>
 @import '../assets/styles/global.scss';
 @import '@blueconduit/copper/scss/01_settings/design-tokens';
 

--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -2,13 +2,7 @@
   <div>
     <PredictionPanel />
     <div class='map-container'>
-      <!--      <MapGeocoderWrapper-->
-      <!--        class='search'-->
-      <!--        :acceptedTypes='acceptedTypes'-->
-      <!--        :baseUrl='SCORECARD_BASE'-->
-      <!--        v-model:expandSearch='showSearch'-->
-      <!--      />-->
-      <ScorecardMapZoomBar />
+      <ScorecardMapSearchBar />
       <NationwideMap height='60vh' :scorecard='true' />
     </div>
     <div class='container-column center-container actions-to-take'
@@ -54,12 +48,10 @@ import NationwideMap from '../components/NationwideMap.vue';
 import LslrSection, { LSLR_CITY_LINKS } from '@/components/LslrSection.vue';
 import { useSelector } from '@/model/store';
 import { LeadDataState } from '../model/states/lead_data_state';
-import { City, GeoType } from '../model/states/model/geo_data';
-import MapGeocoderWrapper from '../components/MapGeocoderWrapper.vue';
+import { City } from '../model/states/model/geo_data';
 import { GeoDataState } from '../model/states/geo_data_state';
 import { GeoDataUtil } from '../util/geo_data_util';
-import SearchBar from '../components/SearchBar.vue';
-import ScorecardMapZoomBar from '../components/ScorecardMapZoomBar.vue';
+import ScorecardMapSearchBar from '../components/ScorecardMapSearchBar.vue';
 
 /**
  * Container for SearchBar and MapContainer.
@@ -69,12 +61,10 @@ export default defineComponent({
   components: {
     ActionSection,
     LslrSection,
-    // MapGeocoderWrapper,
     NationwideMap,
     PredictionPanel,
     ScorecardSummaryPanel,
-    // SearchBar,
-    ScorecardMapZoomBar,
+    ScorecardMapSearchBar,
   },
   setup() {
     const geoState = useSelector((state) => state.geos) as GeoDataState;
@@ -87,8 +77,6 @@ export default defineComponent({
   },
   data() {
     return {
-      acceptedTypes: [GeoType.address, GeoType.postcode],
-      showSearch: true,
       ScorecardMessages,
       SCORECARD_BASE,
       showLslr: false,

--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -10,7 +10,8 @@
       />
       <NationwideMap height='60vh' :scorecard='true' />
     </div>
-    <div class='container-column center-container actions-to-take'>
+    <div class='container-column center-container actions-to-take'
+         v-if='showResultSections'>
       <div class='h1-header-large'>
         {{ ScorecardMessages.TAKE_ACTION_HEADER }}
       </div>
@@ -28,7 +29,7 @@
         @onButtonClick='copyToClipboard'
       />
     </div>
-    <ScorecardSummaryPanel />
+    <ScorecardSummaryPanel v-if='showResultSections' />
     <ActionSection
       class='nav-to-map section'
       :header='ScorecardMessages.WANT_TO_KNOW_MORE'
@@ -54,6 +55,8 @@ import { useSelector } from '@/model/store';
 import { LeadDataState } from '../model/states/lead_data_state';
 import { City, GeoType } from '../model/states/model/geo_data';
 import MapGeocoderWrapper from '../components/MapGeocoderWrapper.vue';
+import { GeoDataState } from '../model/states/geo_data_state';
+import { GeoDataUtil } from '../util/geo_data_util';
 
 /**
  * Container for SearchBar and MapContainer.
@@ -69,9 +72,11 @@ export default defineComponent({
     ScorecardSummaryPanel,
   },
   setup() {
+    const geoState = useSelector((state) => state.geos) as GeoDataState;
     const leadDataState = useSelector((state) => state.leadData) as LeadDataState;
 
     return {
+      geoState,
       leadDataState,
     };
   },
@@ -82,6 +87,7 @@ export default defineComponent({
       ScorecardMessages,
       SCORECARD_BASE,
       showLslr: false,
+      showResultSections: false,
       Titles,
     };
   },
@@ -105,6 +111,9 @@ export default defineComponent({
     'leadDataState.data.city': function () {
       const city = this.leadDataState?.data?.city ?? City.unknown;
       this.showLslr = city != null && LSLR_CITY_LINKS.get(city) != null;
+    },
+    'geoState.geoids': function() {
+      this.showResultSections = !GeoDataUtil.isNullOrEmpty(this.geoState?.geoids);
     },
   },
 });


### PR DESCRIPTION
## Description

Addresses: 
- Hide demographic data when there is no score
- Add side panel from the mocks (added [pills](https://www.figma.com/file/0LGxjZnPD3N0dCqHv8LRr6/NW-Map-Design-System-WIP?node-id=855%3A6331) instead as discussed with Nicole + Justine).
- Restrict pan and zoom on scorecard

### New

Search bar component for map. I made a separate component instead of refactoring the existing searchbar because the existing one will be modified to take out the pills, and the actual content of the choices is different as well (data layer vs zoom level) so most of functionality will not be shared.

### Changed

- Added zoomLevel to mapData which tracks whether the map is zoomed to address, zip, or water system. While this also applies to nationwide map (zooms to bounding box or center), there is no indication there of the enum level (it looks the same as before).

### Removed
- Zoom toggles on map. We got feedback during the bug bash that this was confusing without panning and it is no longer needed with this change.

## Testing and Reviewing

ran locally with different results which had varying levels of zoom available. Test changes at [my sandbox](https://kailajeter.leadout-sandbox.blueconduit.com/scorecard/address/41.7176,-83.477155).