### PR TITLE
Fix lead connections == 0 bug.

### DIFF
--- a/client/src/util/lead_data_util.ts
+++ b/client/src/util/lead_data_util.ts
@@ -30,8 +30,8 @@ export class LeadDataUtil {
    * @param prediction percent lead prediction
    */
   static formatPredictionAsLikelihood(prediction: number | null | undefined): string | null {
-    if (!prediction) return null;
-    
+    if (prediction == null) return null;
+
     switch (true) {
       case prediction <= LeadDataUtil.LOW_LEAD_LIKELIHOOD:
         return ScorecardMessages.LOW_LIKELIHOOD;


### PR DESCRIPTION
Fix bug introduced in https://github.com/BlueConduit/open-data-platform/pull/155/files# which removed the likelihood header when the likelihood == 0 bug.

Bug is currently visible at https://kailajeter.leadout-sandbox.blueconduit.com/scorecard/address/41.716255,-83.643702 but in the process of deploying the fix.
