### PR TITLE
Make scorecard responsive

### DIFF
--- a/client/src/assets/messages/scorecard_messages.ts
+++ b/client/src/assets/messages/scorecard_messages.ts
@@ -12,7 +12,7 @@ export class ScorecardMessages {
     'The Area Deprivation Index (ADI) is based on a measure created by the Health Resources & ' +
     'Services Administration. It includes factors like income, education, employment, and housing quality.';
   static AVERAGE_INCOME = 'Average income';
-  static COPY_TO_CLIPBOARD = 'Copy scorecard to clipboard';
+  static COPY_TO_CLIPBOARD = 'Copy scorecard link';
   static EXPLORE_MAP_PAGE_EXPLAINER =
     'You can learn more about what’s happening in your community, state, ' +
     'or the United States by exploring the Nationwide Map. ';
@@ -39,13 +39,15 @@ export class ScorecardMessages {
   static LEARN_MORE = 'Learn more';
   static LOWER_INCOME = 'Lower income';
   static LSLR_HEADER = 'Lead Service Line Replacement Pilot';
-  static LSLR_SUBHEADER = 'Learn more about lead service replacements happening in your area ' + 
-  'and your eligibility status.';
+  static LSLR_SUBHEADER =
+    'Learn more about lead service replacements happening in your area ' +
+    'and your eligibility status.';
   static RESEARCH_WATER_FILTERS = 'Research water filters';
   static SCORECARD_SUMMARY_PANEL_SUBHEADER =
     'In addition to information from your water system, your score is also based on ' +
     'these statistics for your zip code:';
-  static SHARE_LEAD_OUT = 'Share LeadOut and help others know their status';
+  static SHARE_LEAD_OUT = 'Share your lead score';
+  static SHARE_LEAD_OUT_SUBHEADER = 'Help others know their lead status through LeadOut.';
   static SOMEWHAT_DISADVANTAGED = 'Somewhat disadvantaged';
   static SOMEWHAT_LIKELY = 'somewhat likely';
   static TAKE_ACTION_HEADER = 'Take action';

--- a/client/src/assets/messages/scorecard_messages.ts
+++ b/client/src/assets/messages/scorecard_messages.ts
@@ -55,7 +55,7 @@ export class ScorecardMessages {
   static WATER_SYSTEM_DESCRIPTION =
     'This is the water system which owns the service lines that ' + 'provide water to this area.';
 
-  static SCORECARD_SUMMARY_PANEL_HEADER = (zipCode?: string) =>
+  static SCORECARD_SUMMARY_PANEL_HEADER = (zipCode: string | null) =>
     zipCode != null ? `Understanding your score for ${zipCode}` : 'Understanding your score';
 
   static PREDICTION_EXPLANATION = (prediction: string) =>

--- a/client/src/assets/messages/scorecard_messages.ts
+++ b/client/src/assets/messages/scorecard_messages.ts
@@ -53,7 +53,7 @@ export class ScorecardMessages {
   static TAKE_ACTION_HEADER = 'Take action';
   static WANT_TO_KNOW_MORE = 'Want to know more?';
   static WATER_SYSTEM_DESCRIPTION =
-    'This is the water system which owns the service lines that ' + 'provide water to this area.';
+    'This is the water system which owns the service lines that provide water to this area.';
 
   static SCORECARD_SUMMARY_PANEL_HEADER = (zipCode: string | null) =>
     zipCode != null ? `Understanding your score for ${zipCode}` : 'Understanding your score';

--- a/client/src/components/ActionSection.vue
+++ b/client/src/components/ActionSection.vue
@@ -6,6 +6,7 @@
     <div class='container explain-text' v-if='subheader != null'>
       {{ subheader }}
     </div>
+    <!-- TODO: Align the buttons across all columns. -->
     <button class='gold-button' v-if='buttonText != null' v-on:click='onButtonClick'>
       {{ buttonText }}
     </button>

--- a/client/src/components/ActionSection.vue
+++ b/client/src/components/ActionSection.vue
@@ -3,12 +3,10 @@
     <div class='h2-header-large'>
       {{ header }}
     </div>
-    <div class='explain-text' v-if='subheader != null'>
+    <div class='container explain-text' v-if='subheader != null'>
       {{ subheader }}
     </div>
-    <button class='gold-button'
-            v-if='buttonText != null'
-            v-on:click='onButtonClick'>
+    <button class='gold-button' v-if='buttonText != null' v-on:click='onButtonClick'>
       {{ buttonText }}
     </button>
   </div>
@@ -34,7 +32,7 @@ export default defineComponent({
 });
 </script>
 
-<style scoped lang='scss'>
+<style scoped lang="scss">
 @import '../assets/styles/global.scss';
 @import '@blueconduit/copper/scss/01_settings/design-tokens';
 
@@ -44,7 +42,6 @@ export default defineComponent({
 }
 
 .explain-text {
-  text-align: center;
+  padding: $spacing-md;
 }
-
 </style>

--- a/client/src/components/GeoIdSection.vue
+++ b/client/src/components/GeoIdSection.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class='geoid-section' :class='{selected}'>
-    <div class='h2-header-large geoid'>{{ this.geoId }}</div>
-    <div class='h2-header description'>{{ this.geoIdInfo }}</div>
+  <div class='geoid-section' :class='{ selected }'>
+    <div class='h2-header-large geoid'>{{ geoId }}</div>
+    <div class='h2-header description'>{{ geoIdInfo }}</div>
   </div>
 </template>
 
-<script lang='ts'>
+<script lang="ts">
 import { defineComponent } from 'vue';
 
 /**
@@ -30,7 +30,7 @@ export default defineComponent({
 });
 </script>
 
-<style scoped lang='scss'>
+<style scoped lang="scss">
 @import '../assets/styles/global.scss';
 @import '@blueconduit/copper/scss/01_settings/design-tokens';
 

--- a/client/src/components/PredictionPanel.vue
+++ b/client/src/components/PredictionPanel.vue
@@ -1,39 +1,32 @@
 <template>
-  <div class='container'>
-    <div class='prediction'>
-      <div v-if='showWaterSystemPrediction'>
+  <div class='section is-medium'>
+    <div class='container has-text-centered'>
+      <div>
         <div class='h1-header-xl navy'>
-          {{ formatPredictionAsLikelihood(percentLead) }}
+          {{
+            (() => {
+              if (showWaterSystemPrediction) return formatPredictionAsLikelihood(percentLead);
+              if (showParcelPrediction) return formatPredictionAsLikelihood(publicLeadPercent);
+              if (showNoPrediction) return ScorecardSummaryMessages.NOT_ENOUGH_DATA_AVAILABLE;
+              return ScorecardSummaryMessages.GET_WATER_SCORE;
+            })()
+          }}
         </div>
         <div class='h2-header'>
-          {{ ScorecardSummaryMessages.PREDICTION_EXPLANATION(
-          formatPredictionAsLikelihoodDescriptor(percentLead)) }}
-        </div>
-      </div>
-      <div class='h1-header'
-           v-if='showParcelPrediction'>
-        <div class='h1-header-xl navy'>
-          {{ formatPredictionAsLikelihood(publicLeadPercent) }}
-        </div>
-        <div class='h2-header'>
-          {{ ScorecardSummaryMessages.PREDICTION_EXPLANATION(
-          formatPredictionAsLikelihoodDescriptor(publicLeadPercent)) }}
-        </div>
-      </div>
-      <div class='no-prediction' v-if='showNoPrediction'>
-        <div class='h1-header-xl navy'>
-          {{ ScorecardSummaryMessages.NOT_ENOUGH_DATA_AVAILABLE }}
-        </div>
-        <div class='explain-text'>
-          {{ ScorecardSummaryMessages.NOT_ENOUGH_DATA_EXPLAINED }}
-        </div>
-      </div>
-      <div v-if='emptyGeoData'>
-        <div class='h1-header-large navy'>
-          {{ ScorecardSummaryMessages.GET_WATER_SCORE }}
-        </div>
-        <div class='explain-text'>
-          {{ ScorecardSummaryMessages.LEAD_LIKELIHOOD_EXPLAINED }}
+          {{
+            (() => {
+              if (showWaterSystemPrediction)
+                return ScorecardSummaryMessages.PREDICTION_EXPLANATION(
+                  formatPredictionAsLikelihoodDescriptor(percentLead),
+                );
+              if (showParcelPrediction)
+                return ScorecardSummaryMessages.PREDICTION_EXPLANATION(
+                  formatPredictionAsLikelihoodDescriptor(publicLeadPercent),
+                );
+              if (showNoPrediction) return ScorecardSummaryMessages.NOT_ENOUGH_DATA_EXPLAINED;
+              return ScorecardSummaryMessages.LEAD_LIKELIHOOD_EXPLAINED;
+            })()
+          }}
         </div>
       </div>
       <!--      TODO: show error message when content is finalized and showError is true.-->
@@ -41,7 +34,7 @@
   </div>
 </template>
 
-<script lang='ts'>
+<script lang="ts">
 import { defineComponent } from 'vue';
 import { dispatch, useSelector } from '../model/store';
 import { ScorecardMessages } from '../assets/messages/scorecard_messages';
@@ -97,9 +90,7 @@ export default defineComponent({
     showWaterSystemPrediction(): boolean {
       return (
         // Show water system prediction if it has a value and there is no parcel prediction.
-        !this.showParcelPrediction &&
-        this.pwsId != null &&
-        this.percentLead != null
+        !this.showParcelPrediction && this.pwsId != null && this.percentLead != null
       );
     },
     showPrediction(): boolean {
@@ -114,15 +105,15 @@ export default defineComponent({
   watch: {
     // Listen for changes to pws id or lat, long. Once it changes, a new
     // prediction must be fetched.
-    'geoState.geoids': function() {
+    'geoState.geoids': function () {
       dispatch(clearLeadData());
 
       // Check if an address was queried and another prediction should be
       // fetched.
       if (
-        this.geoState?.geoids?.address != null
-        && this.geoState?.geoids?.lat != null
-        && this.geoState?.geoids?.long != null
+        this.geoState?.geoids?.address != null &&
+        this.geoState?.geoids?.lat != null &&
+        this.geoState?.geoids?.long != null
       ) {
         dispatch(getParcel(this.geoState.geoids.lat, this.geoState.geoids.long));
       }
@@ -131,7 +122,7 @@ export default defineComponent({
         dispatch(getWaterSystem(this.geoState.geoids.pwsId.id));
       }
     },
-    'geoState.status': function() {
+    'geoState.status': function () {
       this.showError = this.geoState?.status?.status == Status.error;
     },
   },
@@ -160,25 +151,10 @@ export default defineComponent({
 });
 </script>
 
-<style scoped lang='scss'>
+<style scoped lang="scss">
 @import '../assets/styles/global.scss';
 @import '@blueconduit/copper/scss/01_settings/design-tokens';
-
-.prediction div {
-  @include container-column;
-  @include center-container;
-}
-
-.container {
-  padding: $spacing-lg;
-}
-
-.center-container {
-  gap: $spacing-lg;
-  padding: 0 3*$spacing-lg 0 3*$spacing-lg;
-}
-
-.justify-right {
-  justify-content: right;
-}
+@import 'bulma/sass/layout/section.sass';
+@import 'bulma/sass/elements/container.sass';
+@import 'bulma/sass/helpers/typography.sass';
 </style>

--- a/client/src/components/PredictionPanel.vue
+++ b/client/src/components/PredictionPanel.vue
@@ -3,30 +3,10 @@
     <div class='container has-text-centered'>
       <div>
         <div class='h1-header-xl navy'>
-          {{
-            (() => {
-              if (showWaterSystemPrediction) return formatPredictionAsLikelihood(percentLead);
-              if (showParcelPrediction) return formatPredictionAsLikelihood(publicLeadPercent);
-              if (showNoPrediction) return ScorecardSummaryMessages.NOT_ENOUGH_DATA_AVAILABLE;
-              return ScorecardSummaryMessages.GET_WATER_SCORE;
-            })()
-          }}
+          {{ predictionString }}
         </div>
         <div class='h2-header'>
-          {{
-            (() => {
-              if (showWaterSystemPrediction)
-                return ScorecardSummaryMessages.PREDICTION_EXPLANATION(
-                  formatPredictionAsLikelihoodDescriptor(percentLead),
-                );
-              if (showParcelPrediction)
-                return ScorecardSummaryMessages.PREDICTION_EXPLANATION(
-                  formatPredictionAsLikelihoodDescriptor(publicLeadPercent),
-                );
-              if (showNoPrediction) return ScorecardSummaryMessages.NOT_ENOUGH_DATA_EXPLAINED;
-              return ScorecardSummaryMessages.LEAD_LIKELIHOOD_EXPLAINED;
-            })()
-          }}
+          {{ explanationString }}
         </div>
       </div>
       <!--      TODO: show error message when content is finalized and showError is true.-->
@@ -69,8 +49,34 @@ export default defineComponent({
     };
   },
   computed: {
-    publicLeadPercent(): number | undefined {
-      return this.leadState?.data?.publicLeadLowPrediction;
+    predictionString(): string {
+      if (this.showWaterSystemPrediction)
+        return (
+          this.formatPredictionAsLikelihood(this.percentLead) ??
+          this.ScorecardSummaryMessages.NOT_ENOUGH_DATA_AVAILABLE
+        );
+      if (this.showParcelPrediction)
+        return (
+          this.formatPredictionAsLikelihood(this.publicLeadPercent) ??
+          this.ScorecardSummaryMessages.NOT_ENOUGH_DATA_AVAILABLE
+        );
+      if (this.showNoPrediction) return this.ScorecardSummaryMessages.NOT_ENOUGH_DATA_AVAILABLE;
+      return this.ScorecardSummaryMessages.GET_WATER_SCORE;
+    },
+    explanationString(): string {
+      if (this.showWaterSystemPrediction)
+        return this.ScorecardSummaryMessages.PREDICTION_EXPLANATION(
+          this.formatPredictionAsLikelihoodDescriptor(this.percentLead) ?? '',
+        );
+      if (this.showParcelPrediction)
+        return this.ScorecardSummaryMessages.PREDICTION_EXPLANATION(
+          this.formatPredictionAsLikelihoodDescriptor(this.publicLeadPercent) ?? '',
+        );
+      if (this.showNoPrediction) return this.ScorecardSummaryMessages.NOT_ENOUGH_DATA_EXPLAINED;
+      return this.ScorecardSummaryMessages.LEAD_LIKELIHOOD_EXPLAINED;
+    },
+    publicLeadPercent(): number | null {
+      return this.leadState?.data?.publicLeadLowPrediction ?? null;
     },
     // Predicted estimate of lead for water systems.
     percentLead(): number | null {
@@ -132,7 +138,7 @@ export default defineComponent({
      * as an adverb.
      * @param prediction percent lead prediction
      */
-    formatPredictionAsLikelihoodDescriptor(prediction: number | undefined): string | null {
+    formatPredictionAsLikelihoodDescriptor(prediction: number | null): string | null {
       if (prediction == null) {
         return null;
       }

--- a/client/src/components/ScorecardMapSearchBar.vue
+++ b/client/src/components/ScorecardMapSearchBar.vue
@@ -7,17 +7,19 @@
         :key='option'
         :text-content='option'
         :selected='getSelected(option)'
-        @click='setSelected(option)' />
+        @click='setSelected(option)'
+      />
     </div>
     <!--    TODO add more descriptive placeholder.-->
     <map-geocoder-wrapper
       :acceptedTypes='acceptedTypes'
       :baseUrl='SCORECARD_BASE'
-      v-model:expandSearch='showSearch' />
+      v-model:expandSearch='showSearch'
+    />
   </div>
 </template>
 
-<script lang='ts'>
+<script lang="ts">
 import { defineComponent } from 'vue';
 import { SCORECARD_BASE } from '../router';
 import SearchBarOption from './SearchBarOption.vue';
@@ -77,17 +79,17 @@ export default defineComponent({
     },
   },
   watch: {
-    'mapState.mapData.zoomLevel': function() {
+    'mapState.mapData.zoomLevel': function () {
       this.selectedOption = this.mapState?.mapData?.zoomLevel ?? null;
     },
-    'geoState.geoids': function() {
+    'geoState.geoids': function () {
       this.options = GeoDataUtil.getZoomOptionsForGeoIds(this.geoState?.geoids);
     },
   },
 });
 </script>
 
-<style scoped lang='scss'>
+<style scoped lang="scss">
 @import '../assets/styles/global.scss';
 @import '@blueconduit/copper/scss/01_settings/design-tokens';
 

--- a/client/src/components/ScorecardSummaryPanel.vue
+++ b/client/src/components/ScorecardSummaryPanel.vue
@@ -1,36 +1,39 @@
 <template>
-  <div class='center-container'>
-    <div class='container-column center-container'>
+  <div class='section is-medium'>
+    <div class='container'>
       <div class='h1-header-large'>
-        <div> {{ ScorecardSummaryMessages.SCORECARD_SUMMARY_PANEL_HEADER(
-          zipCode) }}
-        </div>
+        <div>{{ ScorecardSummaryMessages.SCORECARD_SUMMARY_PANEL_HEADER(zipCode) }}</div>
       </div>
       <div class='subheader'>
         {{ ScorecardSummaryMessages.SCORECARD_SUMMARY_PANEL_SUBHEADER }}
       </div>
       <div class='container-column center-container'>
-        <ScorecardSummaryRow :header='ScorecardSummaryMessages.HOME_AGE'
-                             :subheader='ScorecardSummaryMessages.HOME_AGE_EXPLAINED'
-                             :comparisonValue='homeAgeComparison'
-                             image='home_age.png' />
+        <ScorecardSummaryRow
+          :header='ScorecardSummaryMessages.HOME_AGE'
+          :subheader='ScorecardSummaryMessages.HOME_AGE_EXPLAINED'
+          :comparisonValue='homeAgeComparison'
+          image='home_age.png'
+        />
         <ScorecardSummaryRow
           :header='ScorecardSummaryMessages.AREA_DEPRIVATION_INDEX'
           :subheader='ScorecardSummaryMessages.AREA_DEPRIVATION_INDEX_EXPLAINED'
           :imageFloatDirection='ImageFloatDirection.right'
           :comparisonValue='areaDeprivationIndexComparison'
           learnMoreLink='https://www.neighborhoodatlas.medicine.wisc.edu/'
-          image='vulnerability.png' />
-        <ScorecardSummaryRow :header='ScorecardSummaryMessages.INCOME_LEVEL'
-                             :subheader='ScorecardSummaryMessages.INCOME_LEVEL_EXPLAINED'
-                             :comparisonValue='incomeComparison'
-                             image='income.png' />
+          image='vulnerability.png'
+        />
+        <ScorecardSummaryRow
+          :header='ScorecardSummaryMessages.INCOME_LEVEL'
+          :subheader='ScorecardSummaryMessages.INCOME_LEVEL_EXPLAINED'
+          :comparisonValue='incomeComparison'
+          image='income.png'
+        />
       </div>
     </div>
   </div>
 </template>
 
-<script lang='ts'>
+<script lang="ts">
 import { defineComponent } from 'vue';
 import { ScorecardMessages } from '../assets/messages/scorecard_messages';
 import ScorecardSummaryRow, { ImageFloatDirection } from './ScorecardSummaryRow.vue';
@@ -38,7 +41,7 @@ import { dispatch, useSelector } from '../model/store';
 import { GeoDataState } from '../model/states/geo_data_state';
 import { DemographicDataState } from '../model/states/demographic_data_state';
 import { GeographicLevel } from '../model/data_layer';
-import { clearDemographicData, getDemographicData } from '../model/slices/demographic_data_slice';
+import { getDemographicData } from '../model/slices/demographic_data_slice';
 
 // Taken from https://www.neighborhoodatlas.medicine.wisc.edu/.
 const LOWEST_DISADVANTAGE = 33;
@@ -46,7 +49,6 @@ const MEDIUM_DISADVANTAGE = 66;
 
 const HIGHEST_INCOME_PERCENTILE = 3;
 const MIDDLE_INCOME_PERCENTILE = 6;
-
 
 /**
  * Prediction explanation.
@@ -96,7 +98,9 @@ export default defineComponent({
       }
     },
     areaDeprivationIndexComparison(): string | null {
-      const adi = this.roundNumber(this.demographicDataState?.data?.averageSocialVulnerabilityIndex);
+      const adi = this.roundNumber(
+        this.demographicDataState?.data?.averageSocialVulnerabilityIndex,
+      );
 
       if (adi == null) {
         return null;
@@ -120,7 +124,7 @@ export default defineComponent({
   watch: {
     // Listen for changes to zip code. Once it changes, new demographic info
     // must be fetched.
-    'geoState.geoids.zipCode': function() {
+    'geoState.geoids.zipCode': function () {
       if (this.geoState?.geoids?.zipCode != null) {
         dispatch(getDemographicData(GeographicLevel.Zipcode, this.geoState.geoids.zipCode.id));
       }
@@ -137,11 +141,13 @@ export default defineComponent({
 });
 </script>
 
-<style scoped lang='scss'>
+<style scoped lang="scss">
 @import '../assets/styles/global.scss';
 @import '@blueconduit/copper/scss/01_settings/design-tokens';
+@import 'bulma/sass/layout/section.sass';
+@import 'bulma/sass/elements/container.sass';
 
-.center-container {
+.section {
   background-color: $light-blue;
   color: $white;
 }

--- a/client/src/components/ScorecardSummaryRow.vue
+++ b/client/src/components/ScorecardSummaryRow.vue
@@ -1,13 +1,15 @@
 <template>
-  <div
-    :class='containerRowClass'>
-    <div class='asset'><img :src='require(`@/assets/media/${image}`)' alt=''>
+  <div class='columns is-centered' :class='{ reverse }'>
+    <div class='column asset has-text-centered'>
+      <img :src='require(`@/assets/media/${image}`)' alt='' />
     </div>
-    <div class='factor-text'>
-      <div class='h2-header-large'> {{ header }}</div>
-      <div class='explain-text'> {{ subheader }} <br>
+    <div class='column'>
+      <div class='h2-header-large'>{{ header }}</div>
+      <div class='explain-text'>
+        {{ subheader }} <br />
         <a v-if='learnMoreLink != null' :href='learnMoreLink'>
-          {{ ScorecardMessages.LEARN_MORE }}</a>
+          {{ ScorecardMessages.LEARN_MORE }}</a
+        >
       </div>
       <!--      TODO: Handle error state where there is no demographic data -->
       <!--      after the API has returned.-->
@@ -18,7 +20,7 @@
   </div>
 </template>
 
-<script lang='ts'>
+<script lang="ts">
 import { defineComponent, PropType } from 'vue';
 import { ScorecardMessages } from '../assets/messages/scorecard_messages';
 
@@ -27,7 +29,7 @@ import { ScorecardMessages } from '../assets/messages/scorecard_messages';
  */
 export enum ImageFloatDirection {
   left,
-  right
+  right,
 }
 
 /**
@@ -48,27 +50,19 @@ export default defineComponent({
   },
   data() {
     return {
-      containerRowClass: this.imageFloatDirection == ImageFloatDirection.left
-        ? 'center-container' : 'container-reverse',
+      reverse: this.imageFloatDirection == ImageFloatDirection.right,
       ScorecardMessages,
     };
   },
 });
-
-
 </script>
-<style scoped lang='scss'>
+<style scoped lang="scss">
 @import '../assets/styles/global.scss';
 @import '@blueconduit/copper/scss/01_settings/design-tokens';
+@import 'bulma/sass/grid/columns.sass';
+@import 'bulma/sass/helpers/typography.sass';
 
-.center-container {
-  height: var(--height);
-  gap: $spacing-lg;
-}
-
-.container-reverse {
-  @include center-container;
-
+.reverse {
   flex-direction: row-reverse;
 }
 
@@ -78,16 +72,11 @@ export default defineComponent({
 }
 
 .explain-text {
-  color: white;
-}
-
-.factor-text {
-  @include container-column;
-  gap: $spacing-md;
+  color: $text_white;
+  width: 100%;
 }
 
 .asset img {
   width: 20 * $spacing-md;
 }
-
 </style>

--- a/client/src/components/SidePanel.vue
+++ b/client/src/components/SidePanel.vue
@@ -1,13 +1,16 @@
 <template>
-  <div class='columns is-centered' v-if='options.length > 0'>
-    <geo-id-section
-      v-for='option in options'
-      :key='option'
-      :geoId='getGeoIdForZoomLevel(option)'
-      :geoIdInfo='getGeoIdInfoForZoomLevel(option)'
-      :selected='getSelected(option)'
-      @click='setSelected(option)'
-    />
+  <!-- Vue wants only one root element and v-for can have many, so wrap in a parent div. -->
+  <div>
+    <div class='columns is-centered' v-for='option in options' :key='option'>
+      <div class='column'>
+        <geo-id-section
+          :geoId='getGeoIdForZoomLevel(option)'
+          :geoIdInfo='getGeoIdInfoForZoomLevel(option)'
+          :selected='getSelected(option)'
+          @click='setSelected(option)'
+        />
+      </div>
+    </div>
   </div>
 </template>
 
@@ -144,4 +147,6 @@ export default defineComponent({
 <style scoped lang="scss">
 @import '../assets/styles/global.scss';
 @import '@blueconduit/copper/scss/01_settings/design-tokens';
+@import 'bulma/sass/grid/columns.sass';
+@import 'bulma/sass/helpers/spacing.sass';
 </style>

--- a/client/src/components/SidePanel.vue
+++ b/client/src/components/SidePanel.vue
@@ -1,16 +1,17 @@
 <template>
-  <span class='side-panel' v-if='options.length > 0'>
+  <div class='columns is-centered' v-if='options.length > 0'>
     <geo-id-section
       v-for='option in options'
       :key='option'
       :geoId='getGeoIdForZoomLevel(option)'
       :geoIdInfo='getGeoIdInfoForZoomLevel(option)'
       :selected='getSelected(option)'
-      @click='setSelected(option)' />
-  </span>
+      @click='setSelected(option)'
+    />
+  </div>
 </template>
 
-<script lang='ts'>
+<script lang="ts">
 import { defineComponent } from 'vue';
 import GeoIdSection from './GeoIdSection.vue';
 import { dispatch, useSelector } from '../model/store';
@@ -93,7 +94,8 @@ export default defineComponent({
         case ZoomLevel.parcel:
           return ScorecardMessages.PREDICTION_DESCRIPTION(
             LeadDataUtil.formatPredictionAsLikelihood(
-              this.leadState?.data?.publicLeadLowPrediction),
+              this.leadState?.data?.publicLeadLowPrediction,
+            ),
             'parcel',
           );
         case ZoomLevel.waterSystem:
@@ -101,8 +103,10 @@ export default defineComponent({
         case ZoomLevel.zipCode:
           return ScorecardMessages.PREDICTION_DESCRIPTION(
             LeadDataUtil.formatPredictionAsLikelihood(
-              LeadDataUtil.waterSystemsPercentLead(this.leadState?.data)),
-            'zip code');
+              LeadDataUtil.waterSystemsPercentLead(this.leadState?.data),
+            ),
+            'zip code',
+          );
         default:
           return '';
       }
@@ -127,28 +131,17 @@ export default defineComponent({
     },
   },
   watch: {
-    'mapState.mapData.zoomLevel': function() {
+    'mapState.mapData.zoomLevel': function () {
       this.selectedOption = this.mapState?.mapData?.zoomLevel ?? null;
     },
-    'geoState.geoids': function() {
+    'geoState.geoids': function () {
       this.options = GeoDataUtil.getZoomOptionsForGeoIds(this.geoState?.geoids);
     },
   },
 });
 </script>
 
-<style scoped lang='scss'>
+<style scoped lang="scss">
 @import '../assets/styles/global.scss';
 @import '@blueconduit/copper/scss/01_settings/design-tokens';
-
-
-.side-panel {
-  @include container-column;
-  display: flex;
-  flex-direction: column;
-  padding: $spacing-lg $spacing-xl;
-  justify-content: space-between;
-  row-gap: $spacing-lg;
-}
-
 </style>

--- a/client/src/components/landing_page/ResourcesSection.vue
+++ b/client/src/components/landing_page/ResourcesSection.vue
@@ -1,6 +1,5 @@
 <template>
   <div class='section is-medium is-centered has-text-centered'>
-    <!-- <div class='hero-body'> -->
     <div class='container'>
       <div class='columns'>
         <div class='column header-section'>

--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -1,11 +1,20 @@
 <template>
   <div>
     <PredictionPanel />
-    <div class='map-container'>
-      <ScorecardMapSearchBar />
-      <SidePanel class='side-panel' />
-      <NationwideMap class='nationwide-map' height='60vh' :scorecard='true' />
+
+    <!-- Only display the side-panel, full-width on mobile. -->
+    <ScorecardMapSearchBar class='is-hidden-mobile' />
+    <div class='columns is-variable is-centered'>
+      <div class='column'>
+        <div class='section'>
+          <SidePanel />
+        </div>
+      </div>
+      <div class='column is-two-thirds is-hidden-mobile'>
+        <NationwideMap height='60vh' :scorecard='true' />
+      </div>
     </div>
+
     <div class='section has-text-centered' v-if='showResultSections'>
       <div class='h1-header-large'>
         {{ ScorecardMessages.TAKE_ACTION_HEADER }}
@@ -27,7 +36,9 @@
         />
       </div>
     </div>
+
     <ScorecardSummaryPanel v-if='showResultSections' />
+
     <ActionSection
       class='nav-to-map section'
       :header='ScorecardMessages.WANT_TO_KNOW_MORE'
@@ -35,6 +46,7 @@
       :buttonText='Titles.EXPLORE_NATION_WIDE_MAP'
       @onButtonClick='navigateToMapPage'
     />
+
     <LslrSection v-if='showLslr' :city='leadDataState?.data?.city' />
   </div>
 </template>
@@ -123,12 +135,9 @@ export default defineComponent({
 @import 'bulma/sass/layout/section.sass';
 @import 'bulma/sass/grid/columns.sass';
 @import 'bulma/sass/helpers/typography.sass';
+@import 'bulma/sass/helpers/visibility.sass';
 
 .nav-to-map {
   background-color: $light-blue-50;
-}
-
-.side-panel {
-  float: left;
 }
 </style>

--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -5,24 +5,26 @@
       <ScorecardMapSearchBar />
       <NationwideMap height='60vh' :scorecard='true' />
     </div>
-    <div class='container-column center-container actions-to-take'
-         v-if='showResultSections'>
+    <div class='section has-text-centered' v-if='showResultSections'>
       <div class='h1-header-large'>
         {{ ScorecardMessages.TAKE_ACTION_HEADER }}
       </div>
-      <ActionSection
-        class='section'
-        :header='ScorecardMessages.ADDITIONAL_STEPS_HEADER'
-        :subheader='ScorecardMessages.ADDITIONAL_STEPS_SUBHEADER'
-        :buttonText='ScorecardMessages.RESEARCH_WATER_FILTERS'
-        @onButtonClick='navigateToResourcePage'
-      />
-      <ActionSection
-        class='section'
-        :header='ScorecardMessages.SHARE_LEAD_OUT'
-        :buttonText='ScorecardMessages.COPY_TO_CLIPBOARD'
-        @onButtonClick='copyToClipboard'
-      />
+      <div class='columns is-centered'>
+        <ActionSection
+          class='column is-one-third'
+          :header='ScorecardMessages.ADDITIONAL_STEPS_HEADER'
+          :subheader='ScorecardMessages.ADDITIONAL_STEPS_SUBHEADER'
+          :buttonText='ScorecardMessages.RESEARCH_WATER_FILTERS'
+          @onButtonClick='navigateToResourcePage'
+        />
+        <ActionSection
+          class='column is-one-third'
+          :header='ScorecardMessages.SHARE_LEAD_OUT'
+          :subheader='ScorecardMessages.SHARE_LEAD_OUT_SUBHEADER'
+          :buttonText='ScorecardMessages.COPY_TO_CLIPBOARD'
+          @onButtonClick='copyToClipboard'
+        />
+      </div>
     </div>
     <ScorecardSummaryPanel v-if='showResultSections' />
     <ActionSection
@@ -36,7 +38,7 @@
   </div>
 </template>
 
-<script lang='ts'>
+<script lang="ts">
 import PredictionPanel from '../components/PredictionPanel.vue';
 import ActionSection from '../components/ActionSection.vue';
 import { defineComponent } from 'vue';
@@ -45,8 +47,8 @@ import ScorecardSummaryPanel from '../components/ScorecardSummaryPanel.vue';
 import { ScorecardMessages } from '../assets/messages/scorecard_messages';
 import { Titles } from '../assets/messages/common';
 import NationwideMap from '../components/NationwideMap.vue';
-import LslrSection, { LSLR_CITY_LINKS } from '@/components/LslrSection.vue';
-import { useSelector } from '@/model/store';
+import LslrSection, { LSLR_CITY_LINKS } from '../components/LslrSection.vue';
+import { useSelector } from '../model/store';
 import { LeadDataState } from '../model/states/lead_data_state';
 import { City } from '../model/states/model/geo_data';
 import { GeoDataState } from '../model/states/geo_data_state';
@@ -101,20 +103,23 @@ export default defineComponent({
     },
   },
   watch: {
-    'leadDataState.data.city': function() {
+    'leadDataState.data.city': function () {
       const city = this.leadDataState?.data?.city ?? City.unknown;
       this.showLslr = city != null && LSLR_CITY_LINKS.get(city) != null;
     },
-    'geoState.geoids': function() {
+    'geoState.geoids': function () {
       this.showResultSections = !GeoDataUtil.isNullOrEmpty(this.geoState?.geoids);
     },
   },
 });
 </script>
 
-<style scoped lang='scss'>
+<style scoped lang="scss">
 @import '../assets/styles/global.scss';
 @import '@blueconduit/copper/scss/01_settings/design-tokens';
+@import 'bulma/sass/layout/section.sass';
+@import 'bulma/sass/grid/columns.sass';
+@import 'bulma/sass/helpers/typography.sass';
 
 .actions-to-take {
   padding: $spacing-lg;
@@ -126,13 +131,5 @@ export default defineComponent({
 
 .map-container {
   position: relative;
-}
-
-.search {
-  margin-right: $spacing-md;
-  max-width: 350px;
-  position: absolute;
-  top: $spacing-sm;
-  right: 0;
 }
 </style>


### PR DESCRIPTION
## Description

Addresses: [Mobile Optimization](https://tables.area120.google.com/table/bX_kMNBW8LA35n6l5Hz_co/row/9ZLTEnkXfJeetgENepdkVs)

Like https://github.com/BlueConduit/open-data-platform/pull/153, this switches a lot of our layout CSS to use Bulma to make the scorecard responsive. 

### Changed

- Pretty much all of the scorecard and its components.
- The map is hidden is mobile, leaving only the side panel.
- Refactored PredictionPanel to simplify the template.

## Testing and Reviewing

You can play around with the UI on my sandbox: https://beekley.leadout-sandbox.blueconduit.com/

<img width="506" alt="image" src="https://user-images.githubusercontent.com/4321880/188996934-19f3614b-18bb-48ab-bd13-55898c6b5a30.png">

<img width="1644" alt="image" src="https://user-images.githubusercontent.com/4321880/188996949-c0e5fe1c-00d3-4c68-bc92-0d0a88a61de4.png">

