### PR TITLE
API Fixes + Scorecard loading screen

### DIFF
--- a/api/src/geolocate/get.handler.ts
+++ b/api/src/geolocate/get.handler.ts
@@ -5,6 +5,7 @@ import { ExecuteStatementRequest, SqlParametersList } from 'aws-sdk/clients/rdsd
 import { CORS_HEADERS } from '../util';
 
 const SCHEMA = 'public';
+const ID_FIELD = 'id';
 
 /**
  * Returns all geo identifiers that intersect with a lat, long.
@@ -20,7 +21,7 @@ async function getGeoDataForLatLong(
   params: SqlParametersList,
   geoid: string,
   table: string,
-  orderByField?: string,
+  orderByField: string = ID_FIELD,
   orderByAsc: boolean = true,
 ): Promise<BoundedGeoDatum | undefined> {
   // TODO(breuch): Consider updating this to all geoids when we support
@@ -49,7 +50,7 @@ async function getGeoDataForLatLong(
             SELECT ${geoid} AS id, geom AS geom
             FROM ${table}
             WHERE ST_Contains(geom, ST_SetSRID(ST_Point(:long, :lat), 4326))
-            ORDER BY ${orderByField == null ? 'id' : orderByField} ${orderByAsc ? 'ASC' : 'DESC'}
+            ORDER BY ${orderByField} ${orderByAsc ? 'ASC' : 'DESC'}
             LIMIT 1
             )
         SELECT STRING_AGG(id, '|') AS id,
@@ -126,7 +127,7 @@ export const handler = async (event: {
           'pws_id',
           'water_systems',
           'service_connections_count',
-          /* orderByAsc= */false)
+          /* orderByAsc= */ false)
         .then(
         (pws_id) => (body.water_system_pws_id = pws_id),
       ),

--- a/api/src/geolocate/get.handler.ts
+++ b/api/src/geolocate/get.handler.ts
@@ -125,7 +125,7 @@ export const handler = async (event: {
           params,
           'pws_id',
           'water_systems',
-          'lead_connections_count',
+          'service_connections_count',
           /* orderByAsc= */false)
         .then(
         (pws_id) => (body.water_system_pws_id = pws_id),

--- a/api/src/watersystem/get.handler.ts
+++ b/api/src/watersystem/get.handler.ts
@@ -6,6 +6,7 @@ import { CORS_HEADERS } from '../util';
 
 const SCHEMA = 'public';
 const SQL_QUERY = `SELECT pws_id,
+                          pws_name,
                           lead_connections_count,
                           service_connections_count
                    FROM water_systems
@@ -29,8 +30,9 @@ async function getWaterSystemData(
   for (let record of results.records ?? []) {
     body = {
       pws_id: record[0].stringValue,
-      lead_service_lines: record[1].doubleValue,
-      service_lines: record[2].doubleValue,
+      pws_name: record[1].stringValue,
+      lead_service_lines: record[2].doubleValue,
+      service_lines: record[3].doubleValue,
     };
   }
   return body;
@@ -72,8 +74,10 @@ export const handler = async (event: {
  * Information for a requested water system.
  */
 interface WaterSystemApiResponse {
-  // Water system id
+  // Water system id.
   pws_id?: string;
+  // Water system name.
+  pws_name?: string;
   lead_service_lines?: number;
   service_lines?: number;
 }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -19,6 +19,7 @@
         "mapbox-gl": "^2.8.2",
         "sass-loader": "^13.0.2",
         "vue": "^3.2.13",
+        "vue-loading-overlay": "^5.0.3",
         "vue-router": "^4.0.14",
         "vue-select": "^4.0.0-beta.3"
       },
@@ -13901,6 +13902,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/vue-loading-overlay": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vue-loading-overlay/-/vue-loading-overlay-5.0.3.tgz",
+      "integrity": "sha512-6JWZalwlHF4do3HXsFZGt6PcWYseAI5FuNKpveEkljkzqskDWRr7rYmYHVx2kKu4qIvK0vLpL25T/hpFMNoevQ==",
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
+    },
     "node_modules/vue-router": {
       "version": "4.0.14",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.0.14.tgz",
@@ -25099,6 +25111,12 @@
           }
         }
       }
+    },
+    "vue-loading-overlay": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vue-loading-overlay/-/vue-loading-overlay-5.0.3.tgz",
+      "integrity": "sha512-6JWZalwlHF4do3HXsFZGt6PcWYseAI5FuNKpveEkljkzqskDWRr7rYmYHVx2kKu4qIvK0vLpL25T/hpFMNoevQ==",
+      "requires": {}
     },
     "vue-router": {
       "version": "4.0.14",

--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,7 @@
     "mapbox-gl": "^2.8.2",
     "sass-loader": "^13.0.2",
     "vue": "^3.2.13",
+    "vue-loading-overlay": "^5.0.3",
     "vue-router": "^4.0.14",
     "vue-select": "^4.0.0-beta.3"
   },

--- a/client/src/api/api_client.ts
+++ b/client/src/api/api_client.ts
@@ -1,7 +1,6 @@
 import axios, { AxiosError } from 'axios';
 import axiosRetry from 'axios-retry';
 import { GeographicLevel } from '@/model/data_layer';
-import prefixes from '../../../cdk/src/open-data-platform/frontend/url-prefixes';
 
 /**
  * Client to interface with API.
@@ -91,6 +90,7 @@ class ApiClient {
     return this.request(`${ApiClient.API_URL}/watersystem/${pwsId}`, (data) => {
       return {
         pwsId: data?.data?.pws_id,
+        pwsName: data?.data?.pws_name,
         leadServiceLines: data?.data?.lead_service_lines,
         serviceLines: data?.data?.service_lines,
       };

--- a/client/src/components/NationwideMap.vue
+++ b/client/src/components/NationwideMap.vue
@@ -432,6 +432,9 @@ export default defineComponent({
       this.toggleDataOnZoom();
     },
 
+    /**
+     * Sets bounds, center, and marker on map using the geo state geo IDs.
+     */
     updateMapWithGeoIds(): void {
       // Remove the old marker.
       if (this.marker != null) {
@@ -463,6 +466,7 @@ export default defineComponent({
   },
   mounted() {
     if (this.map == null) this.createMap();
+    // Set initial map values with initial geo IDs.
     this.updateMapWithGeoIds();
   },
   watch: {

--- a/client/src/components/NationwideMap.vue
+++ b/client/src/components/NationwideMap.vue
@@ -431,27 +431,8 @@ export default defineComponent({
       dispatch(setZoom(zoom));
       this.toggleDataOnZoom();
     },
-  },
-  mounted() {
-    if (this.map == null) this.createMap();
-  },
-  watch: {
-    // Listens to map state to toggle different layers.
-    'mapState.mapData.currentDataLayerId': {
-      handler: function(newDataLayerId: MapLayer) {
-        if (newDataLayerId == null) {
-          return;
-        }
-        if (this.map?.isStyleLoaded()) {
-          this.updateMapOnDataLayerChange(ALL_DATA_LAYERS.get(newDataLayerId));
-        }
-      },
-    },
-    'mapState.mapData.zoomLevel': function() {
-      this.updateZoomLevel();
-    },
-    // Listen for changes to lat/long to update map location.
-    'geoState.geoids': function() {
+
+    updateMapWithGeoIds(): void {
       // Remove the old marker.
       if (this.marker != null) {
         this.marker.remove();
@@ -478,6 +459,30 @@ export default defineComponent({
           });
         }
       }
+    },
+  },
+  mounted() {
+    if (this.map == null) this.createMap();
+    this.updateMapWithGeoIds();
+  },
+  watch: {
+    // Listens to map state to toggle different layers.
+    'mapState.mapData.currentDataLayerId': {
+      handler: function(newDataLayerId: MapLayer) {
+        if (newDataLayerId == null) {
+          return;
+        }
+        if (this.map?.isStyleLoaded()) {
+          this.updateMapOnDataLayerChange(ALL_DATA_LAYERS.get(newDataLayerId));
+        }
+      },
+    },
+    'mapState.mapData.zoomLevel': function() {
+      this.updateZoomLevel();
+    },
+    // Listen for changes to lat/long to update map location.
+    'geoState.geoids': function() {
+      this.updateMapWithGeoIds();
     },
   },
 });

--- a/client/src/components/PredictionPanel.vue
+++ b/client/src/components/PredictionPanel.vue
@@ -43,9 +43,8 @@
 
 <script lang='ts'>
 import { defineComponent } from 'vue';
-import { dispatch, useSelector } from '../model/store';
+import { useSelector } from '../model/store';
 import { ScorecardMessages } from '../assets/messages/scorecard_messages';
-import { clearLeadData, getParcel, getWaterSystem } from '../model/slices/lead_data_slice';
 import { GeoDataState } from '../model/states/geo_data_state';
 import { LeadDataState } from '../model/states/lead_data_state';
 import { BoundedGeoDatum, GeoType } from '../model/states/model/geo_data';
@@ -112,25 +111,6 @@ export default defineComponent({
     },
   },
   watch: {
-    // Listen for changes to pws id or lat, long. Once it changes, a new
-    // prediction must be fetched.
-    'geoState.geoids': function() {
-      dispatch(clearLeadData());
-
-      // Check if an address was queried and another prediction should be
-      // fetched.
-      if (
-        this.geoState?.geoids?.address != null
-        && this.geoState?.geoids?.lat != null
-        && this.geoState?.geoids?.long != null
-      ) {
-        dispatch(getParcel(this.geoState.geoids.lat, this.geoState.geoids.long));
-      }
-      // Request water system data if PWSID is not null, even for address search.
-      if (this.geoState?.geoids?.pwsId != null) {
-        dispatch(getWaterSystem(this.geoState.geoids.pwsId.id));
-      }
-    },
     'geoState.status': function() {
       this.showError = this.geoState?.status?.status == Status.error;
     },

--- a/client/src/components/ScorecardMapSearchBar.vue
+++ b/client/src/components/ScorecardMapSearchBar.vue
@@ -53,7 +53,7 @@ export default defineComponent({
       acceptedTypes: [GeoType.address, GeoType.postcode],
       options: [] as ZoomLevel[],
       selectedOption: null as ZoomLevel | null,
-      showSearch: true,
+      showSearch: false,
       SCORECARD_BASE,
     };
   },

--- a/client/src/components/ScorecardMapSearchBar.vue
+++ b/client/src/components/ScorecardMapSearchBar.vue
@@ -57,6 +57,10 @@ export default defineComponent({
       SCORECARD_BASE,
     };
   },
+  beforeMount() {
+    this.options = GeoDataUtil.getZoomOptionsForGeoIds(this.geoState?.geoids);
+    this.selectedOption = this.mapState?.mapData?.zoomLevel ?? null;
+  },
   methods: {
     /**
      * Returns whether {@code option} is the selected option.

--- a/client/src/components/SidePanel.vue
+++ b/client/src/components/SidePanel.vue
@@ -52,15 +52,18 @@ export default defineComponent({
      * Returns the geo ID value corresponding to the given zoom level.
      */
     getGeoIdForZoomLevel(level: ZoomLevel): string | undefined {
+      const waterSystemName: string | undefined = this.leadState?.data?.pwsName?.toLowerCase();
       const geoIds: GeoData | undefined = this.geoState?.geoids;
       if (GeoDataUtil.isNullOrEmpty(geoIds)) return;
 
       switch (level) {
         case ZoomLevel.parcel:
           return this.formatAddress(geoIds?.address?.id);
-        // TODO: return water system name instead of ID.
+        // Prefer human-readable water system name but fall back on required water system ID.
         case ZoomLevel.waterSystem:
-          return geoIds?.pwsId?.id;
+          return waterSystemName == null || waterSystemName == ''
+            ? geoIds?.pwsId?.id
+            : waterSystemName;
         case ZoomLevel.zipCode:
           return geoIds?.zipCode?.id;
         default:

--- a/client/src/components/SidePanel.vue
+++ b/client/src/components/SidePanel.vue
@@ -47,6 +47,10 @@ export default defineComponent({
       ZoomLevel,
     };
   },
+  beforeMount() {
+    this.options = GeoDataUtil.getZoomOptionsForGeoIds(this.geoState?.geoids);
+    this.selectedOption = this.mapState?.mapData?.zoomLevel ?? null;
+  },
   methods: {
     /**
      * Returns the geo ID value corresponding to the given zoom level.

--- a/client/src/components/landing_page/ExploreMapSection.vue
+++ b/client/src/components/landing_page/ExploreMapSection.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class='section is-small is-centered has-text-centered'>
-    <div class='columns'>
+  <div class='section is-small has-text-centered'>
+    <div class='columns is-centered'>
       <div class='column is-two-thirds'>
         <div class='header-section'>
           <div class='h1-header-large'>

--- a/client/src/components/landing_page/FilterInfoSection.vue
+++ b/client/src/components/landing_page/FilterInfoSection.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class='section is-small is-centered has-text-centered'>
-    <div class='columns'>
+  <div class='section is-small has-text-centered'>
+    <div class='columns is-centered'>
       <div class='column is-two-thirds'>
         <div class='header-section'>
           <div class='h2-header-large'>

--- a/client/src/components/landing_page/ResourcesSection.vue
+++ b/client/src/components/landing_page/ResourcesSection.vue
@@ -7,12 +7,14 @@
           <div class='h2-header-large'>
             {{ messages.RESOURCES_SECTION_SUPER_HEADER }}
           </div>
-          <div class='h1-header-large'>{{ messages.RESOURCES_SECTION_HEADER }}
+          <div class='h1-header-large'>
+            {{ messages.RESOURCES_SECTION_HEADER }}
           </div>
         </div>
       </div>
       <div class='columns'>
-        <div class='column' v-for='resource in messages.RESOURCE_MESSAGES'
+        <div class='column'
+             v-for='resource in messages.RESOURCE_MESSAGES'
              :key='resource.header'>
           <div class='h1-header'>{{ resource.header }}</div>
           <div class='resource-blurb body'>{{ resource.body }}</div>

--- a/client/src/components/landing_page/ResourcesSection.vue
+++ b/client/src/components/landing_page/ResourcesSection.vue
@@ -1,15 +1,19 @@
 <template>
-  <div class='section is-medium is-centered has-text-centered'>
+  <div class='section is-medium has-text-centered'>
     <!-- <div class='hero-body'> -->
     <div class='container'>
-      <div class='columns'>
+      <div class='columns is-centered'>
         <div class='column header-section'>
-          <div class='h2-header-large'>{{ messages.RESOURCES_SECTION_SUPER_HEADER }}</div>
-          <div class='h1-header-large'>{{ messages.RESOURCES_SECTION_HEADER }}</div>
+          <div class='h2-header-large'>
+            {{ messages.RESOURCES_SECTION_SUPER_HEADER }}
+          </div>
+          <div class='h1-header-large'>{{ messages.RESOURCES_SECTION_HEADER }}
+          </div>
         </div>
       </div>
       <div class='columns'>
-        <div class='column' v-for='resource in messages.RESOURCE_MESSAGES' :key='resource.header'>
+        <div class='column' v-for='resource in messages.RESOURCE_MESSAGES'
+             :key='resource.header'>
           <div class='h1-header'>{{ resource.header }}</div>
           <div class='resource-blurb body'>{{ resource.body }}</div>
         </div>

--- a/client/src/components/landing_page/ResourcesSection.vue
+++ b/client/src/components/landing_page/ResourcesSection.vue
@@ -1,6 +1,5 @@
 <template>
   <div class='section is-medium has-text-centered'>
-    <!-- <div class='hero-body'> -->
     <div class='container'>
       <div class='columns is-centered'>
         <div class='column header-section'>

--- a/client/src/components/landing_page/SearchSection.vue
+++ b/client/src/components/landing_page/SearchSection.vue
@@ -1,10 +1,11 @@
 <template>
-  <div class='section is-large is-centered has-text-centered'>
-    <div class='columns'>
+  <div class='section is-large has-text-centered'>
+    <div class='columns is-centered'>
       <div class='column is-two-thirds'>
         <div class='header-section'>
           <div class='h1-header-xl'>{{ messages.SEARCH_SECTION_HEADER }}</div>
-          <div class='h2-header-large'>{{ messages.SEARCH_SECTION_SUBHEADER }}</div>
+          <div class='h2-header-large'>{{ messages.SEARCH_SECTION_SUBHEADER }}
+          </div>
         </div>
         <ScorecardSearch
           :placeholder='messages.GEOLOCATE_PLACEHOLDER_TEXT'

--- a/client/src/model/slices/lead_data_slice.ts
+++ b/client/src/model/slices/lead_data_slice.ts
@@ -14,11 +14,18 @@ const leadDataSlice = createSlice({
   name: 'leadDataSlice',
   initialState,
   reducers: {
+    parcelQueried(state: LeadDataState, action: PayloadAction<LeadData>) {
+      return {
+        ...state,
+        data: { ...state.data, ...action.payload },
+        parcelStatus: { status: Status.pending },
+      };
+    },
     getParcelSuccess(state: LeadDataState, action: PayloadAction<LeadData>) {
       return {
         ...state,
         data: { ...state.data, ...action.payload },
-        status: { status: Status.success },
+        parcelStatus: { status: Status.success },
       };
     },
     getParcelError: (state: LeadDataState, action) => {
@@ -26,7 +33,7 @@ const leadDataSlice = createSlice({
         `Error fetching lead data for parcel: ${JSON.stringify(state)} ${JSON.stringify(action)}`,
       );
       return {
-        status: {
+        parcelStatus: {
           status: Status.error,
           message: action.payload.error,
           code: action.payload.status,
@@ -37,7 +44,7 @@ const leadDataSlice = createSlice({
       return {
         ...state,
         data: { ...state.data, ...action.payload },
-        status: { status: Status.success },
+        waterSystemStatus: { status: Status.success },
       };
     },
     getWaterSystemError: (state: LeadDataState, action) => {
@@ -47,7 +54,7 @@ const leadDataSlice = createSlice({
         )}`,
       );
       return {
-        status: {
+        waterSystemStatus: {
           status: Status.error,
           message: action.payload.error,
           code: action.payload.status,
@@ -58,13 +65,14 @@ const leadDataSlice = createSlice({
       return {
         ...state,
         data: { ...state.data, ...action.payload },
-        status: { status: Status.pending },
+        waterSystemStatus: { status: Status.pending },
       };
     },
     leadDataCleared(_: LeadDataState, __: PayloadAction<LeadData>) {
       return {
         data: {},
-        status: { status: Status.success },
+        parcelStatus: { status: Status.success },
+        waterSystemStatus: { status: Status.success },
       };
     },
   },
@@ -78,6 +86,8 @@ const leadDataSlice = createSlice({
  */
 export const getParcel = (lat: string, long: string) => {
   return async (dispatch: AppDispatch) => {
+    dispatch(parcelQueried({ lat: lat, long: long }));
+
     const apiResponse = await client.getParcel(lat, long);
     if (apiResponse.data != null) {
       dispatch(getParcelSuccess(apiResponse.data));
@@ -123,5 +133,6 @@ export const {
   getWaterSystemSuccess,
   getWaterSystemError,
   leadDataCleared,
+  parcelQueried,
 } = leadDataSlice.actions;
 export default leadDataSlice.reducer;

--- a/client/src/model/states/lead_data_state.ts
+++ b/client/src/model/states/lead_data_state.ts
@@ -6,5 +6,6 @@ import { StatusState } from '@/model/states/status_state';
  */
 export interface LeadDataState {
   data?: LeadData;
-  status?: StatusState;
+  waterSystemStatus?: StatusState;
+  parcelStatus?: StatusState;
 }

--- a/client/src/model/states/lead_data_state.ts
+++ b/client/src/model/states/lead_data_state.ts
@@ -6,6 +6,7 @@ import { StatusState } from '@/model/states/status_state';
  */
 export interface LeadDataState {
   data?: LeadData;
+  // TODO: move to single status when we have API error to signal no rows returned.
   waterSystemStatus?: StatusState;
   parcelStatus?: StatusState;
 }

--- a/client/src/model/states/model/lead_data.ts
+++ b/client/src/model/states/model/lead_data.ts
@@ -7,6 +7,7 @@ export interface LeadData {
   address?: string;
   city?: City;
   pwsId?: string;
+  pwsName?: string;
   leadServiceLines?: number;
   serviceLines?: number;
   publicLeadLowPrediction?: number;

--- a/client/src/model/states/model/lead_data.ts
+++ b/client/src/model/states/model/lead_data.ts
@@ -4,6 +4,8 @@
 import { City } from '@/model/states/model/geo_data';
 
 export interface LeadData {
+  lat?: string,
+  long?: string,
   address?: string;
   city?: City;
   pwsId?: string;

--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -1,8 +1,12 @@
 <template>
-  <div v-if='!showView'>
-
+  <div class='loading' v-if='!showView'>
+    <loading :active='true'
+             :is-full-page='false' />
   </div>
   <div v-if='showView'>
+    <!--  <div>-->
+    <!--    <loading :active='!showView'-->
+    <!--             :is-full-page='false' />-->
     <PredictionPanel />
     <div class='map-container'>
       <ScorecardMapSearchBar />
@@ -59,6 +63,8 @@ import { City } from '../model/states/model/geo_data';
 import { Status } from '../model/states/status_state';
 import { getParcel, getWaterSystem } from '../model/slices/lead_data_slice';
 import { GeoDataUtil } from '../util/geo_data_util';
+import Loading from 'vue-loading-overlay';
+import 'vue-loading-overlay/dist/vue-loading.css';
 
 /**
  * Container for SearchBar and MapContainer.
@@ -67,6 +73,7 @@ export default defineComponent({
   name: 'ScorecardView',
   components: {
     ActionSection,
+    Loading,
     LslrSection,
     NationwideMap,
     PredictionPanel,
@@ -105,7 +112,6 @@ export default defineComponent({
   },
   beforeMount() {
     if (GeoDataUtil.isNullOrEmpty(this.geoState?.geoids)) {
-      console.log('HERE!!!!: in beforeMount');
       this.showView = true;
       this.showResultSections = false;
       return;
@@ -169,7 +175,6 @@ export default defineComponent({
       this.checkLeadDataStatus();
     },
     'geoState.status': function() {
-      console.log('HERE!!!!: geo state status updating! ' + this.geoState?.status?.status);
       if (this.geoState?.status?.status == Status.pending) {
         this.showView = false;
       }
@@ -183,7 +188,13 @@ export default defineComponent({
 @import '@blueconduit/copper/scss/01_settings/design-tokens';
 
 .actions-to-take {
+  width: 100%;
   padding: $spacing-lg;
+}
+
+.loading {
+  position: relative;
+  height: 100%;
 }
 
 .nav-to-map {

--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -52,7 +52,7 @@ import ScorecardSummaryPanel from '../components/ScorecardSummaryPanel.vue';
 import { ScorecardMessages } from '../assets/messages/scorecard_messages';
 import { Titles } from '../assets/messages/common';
 import NationwideMap from '../components/NationwideMap.vue';
-import LslrSection, { LSLR_CITY_LINKS } from '@/components/LslrSection.vue';
+import LslrSection from '@/components/LslrSection.vue';
 import { dispatch, useSelector } from '@/model/store';
 import { LeadDataState } from '../model/states/lead_data_state';
 import { GeoDataState } from '../model/states/geo_data_state';
@@ -94,7 +94,6 @@ export default defineComponent({
       ScorecardMessages,
       SCORECARD_BASE,
       showResultSections: false,
-      showLslr: false,
       Titles,
     };
 
@@ -108,8 +107,6 @@ export default defineComponent({
         ?? GeoDataUtil.getCityForLatLong(this.geoState?.geoids?.lat, this.geoState?.geoids?.long);
       return intersectedCity ?? City.unknown;
     },
-  },
-  computed: {
     leadDataLoaded(): boolean {
       return this.leadDataState?.waterSystemStatus?.status == Status.success
         && this.leadDataState?.parcelStatus?.status == Status.success;
@@ -158,10 +155,6 @@ export default defineComponent({
     // prediction must be fetched.
     'geoState.geoids': function() {
       this.updateViewWithGeoIds();
-    },
-    'leadDataState.data.city': function() {
-      const city = this.leadDataState?.data?.city ?? City.unknown;
-      this.showLslr = city != null && LSLR_CITY_LINKS.get(city) != null;
     },
   },
 });

--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -1,7 +1,9 @@
 <template>
   <div class='loading' v-if='!showScorecard'>
     <loading :active='true'
-             :is-full-page='false' />
+             :is-full-page='false'
+             color='#2553A0'
+             loader='bars' />
   </div>
   <div v-if='showScorecard'>
     <PredictionPanel />

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "@blueconduit/copper": "^2.0.1",
+        "aws-cdk": "^2.40.0",
         "vue-router": "^4.0.15"
       },
       "devDependencies": {
@@ -1679,6 +1680,20 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/aws-cdk": {
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.40.0.tgz",
+      "integrity": "sha512-oHacGkLFDELwhpJsZSAhFHWDxIeZW3DgKkwiXlNO81JxNfjcHgPR2rsbh/Gz+n4ErAEzOV6WfuWVMe68zv+iPg==",
+      "bin": {
+        "cdk": "bin/cdk"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
       }
     },
     "node_modules/balanced-match": {
@@ -9637,6 +9652,14 @@
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
         "postcss-value-parser": "^4.2.0"
+      }
+    },
+    "aws-cdk": {
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.40.0.tgz",
+      "integrity": "sha512-oHacGkLFDELwhpJsZSAhFHWDxIeZW3DgKkwiXlNO81JxNfjcHgPR2rsbh/Gz+n4ErAEzOV6WfuWVMe68zv+iPg==",
+      "requires": {
+        "fsevents": "2.3.2"
       }
     },
     "balanced-match": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   },
   "dependencies": {
     "@blueconduit/copper": "^2.0.1",
+    "aws-cdk": "^2.40.0",
     "vue-router": "^4.0.15"
   }
 }


### PR DESCRIPTION
## Description

Addresses: 

- Add loading indicator while the page loads data (both map and status): uses https://www.npmjs.com/package/vue-loading-overlay
- Modify API to prefer row with data (specifically water_systems, has multiple entries for some lat/longs)
- Bug with landing page Bulma implementation

Loading indicator:
This PR distinguishes water system data load status from parcel data load status in order to show the loading spinner before both sets of data return. This was causing water system data to render before parcel data in cases where there were both. 

Modify API to prefer row with data:
This sorts by # of service lines to prefer the intersecting water system which serves the largest population of people.

### Changed

- Single status in leadState to water system / parcel statuses

## Testing and Reviewing

tested locally + in sandbox: https://kailajeter.leadout-sandbox.blueconduit.com/