### PR TITLE
Add support for New Orleans + Richmond to LSLR section

### DIFF
--- a/cdk/src/open-data-platform/data-plane/data-import/write-parcels-data.handler.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/write-parcels-data.handler.ts
@@ -4,7 +4,7 @@ import { ParcelsTableRowBuilder } from '../model/parcels-table';
 import { geoJsonHandlerFactory } from './handler-factory';
 
 const SCHEMA = 'schema';
-const CITY = 'toledo';
+const CITY = 'Toledo';
 
 // This file contains < 145k rows
 const s3Params = {

--- a/client/src/components/LslrSection.vue
+++ b/client/src/components/LslrSection.vue
@@ -18,6 +18,8 @@ import { ScorecardMessages as messages } from '@/assets/messages/scorecard_messa
 import { City } from '@/model/states/model/geo_data';
 
 export const LSLR_CITY_LINKS: Map<City, string> = new Map<City, string>([
+  [City.newOrleans, 'https://www.swbno.org/DrinkingWater/LeadAwareness'],
+  [City.richmond, 'https://www.rva.gov/public-utilities/water-utility#collapse-accordion-10788-3'],
   [City.toledo, 'https://toledo.oh.gov/residents/water/lead-service-lines/customer-side'],
 ]);
 

--- a/client/src/components/NationwideMap.vue
+++ b/client/src/components/NationwideMap.vue
@@ -18,6 +18,7 @@ import { MapDataState } from '../model/states/map_data_state';
 import { ALL_DATA_LAYERS, setCurrentDataLayer, setZoom, setZoomLevel } from '../model/slices/map_data_slice';
 import { ZoomLevel } from '../model/states/model/map_data';
 import { BoundingBox, GeoType } from '../model/states/model/geo_data';
+import { TOLEDO_BOUNDS } from '../util/geo_data_util';
 
 const DEFAULT_LNG_LAT = [-98.5556199, 39.8097343];
 
@@ -28,14 +29,6 @@ const VISIBLE = 'visible';
 
 const PARCEL_ZOOM_LEVEL = 16;
 const DEFAULT_ZOOM_LEVEL = 4;
-
-// Define Toledo geometry bounding box to restrict parcel data layer to Toledo.
-// This is needed because we only have parcel-level predictions for Toledo, so this data layer will
-// be empty outside of these boundaries.
-const TOLEDO_BOUNDS: [LngLatLike, LngLatLike] = [
-  [-84.3995471043526, 41.165751],
-  [-82.711584, 41.742764],
-];
 
 /**
  * A browsable map of nationwide lead data.
@@ -381,10 +374,9 @@ export default defineComponent({
      */
     toledoContainsMap(): boolean {
       if (this.map == null) return false;
-      const toledoBounds = new LngLatBounds(TOLEDO_BOUNDS);
       return (
-        toledoBounds.contains(this.map.getBounds().getNorthEast()) &&
-        toledoBounds.contains(this.map.getBounds().getSouthWest())
+        TOLEDO_BOUNDS.contains(this.map.getBounds().getNorthEast()) &&
+        TOLEDO_BOUNDS.contains(this.map.getBounds().getSouthWest())
       );
     },
 

--- a/client/src/components/SidePanel.vue
+++ b/client/src/components/SidePanel.vue
@@ -76,7 +76,7 @@ export default defineComponent({
      * 5150 riviera dr, toledo oh 43611 -> 5150 riviera dr, toledo OH 43611.
      */
     formatAddress(rawAddress: string | undefined): string | undefined {
-      const city = this.leadState?.data?.city;
+      const city = this.leadState?.data?.city?.toLowerCase();
       if (!city || !rawAddress) return rawAddress;
 
       const address = rawAddress.toLowerCase();

--- a/client/src/model/states/model/geo_data.ts
+++ b/client/src/model/states/model/geo_data.ts
@@ -18,12 +18,14 @@ enum GeoType {
 }
 
 /**
- * Represents cities which we have parcel data for.
+ * Represents supported cities.
  *
  * Used to display city-specific information.
  */
 enum City {
-  toledo = 'toledo',
+  toledo = 'Toledo',
+  richmond = 'Richmond',
+  newOrleans = 'New Orleans',
   unknown = 'unknown',
 }
 

--- a/client/src/util/geo_data_util.ts
+++ b/client/src/util/geo_data_util.ts
@@ -1,5 +1,22 @@
-import { GeoData } from '@/model/states/model/geo_data';
+import { City, GeoData } from '@/model/states/model/geo_data';
 import { ZoomLevel } from '@/model/states/model/map_data';
+import { LngLatBounds, LngLatLike } from 'mapbox-gl';
+
+// Define Toledo geometry bounding box to restrict parcel data layer to Toledo.
+// This is needed because we only have parcel-level predictions for Toledo, so this data layer will
+// be empty outside of these boundaries.
+const NEW_ORLEANS_BOUNDS =
+  new LngLatBounds([[-90.60946799999999, 29.699838], [-89.796438, 30.106005999999997]]);
+const RICHMOND_BOUNDS =
+  new LngLatBounds([[-77.732045, 37.149377], [-77.223017, 37.77774]]);
+const TOLEDO_BOUNDS =
+  new LngLatBounds([[-84.3995471043526, 41.165751], [-82.711584, 41.742764]]);
+
+const CITY_BOUNDS = new Map([
+  [NEW_ORLEANS_BOUNDS, City.newOrleans],
+  [RICHMOND_BOUNDS, City.richmond],
+  [TOLEDO_BOUNDS, City.toledo],
+]);
 
 /**
  * Utility functions for the GeoData type.
@@ -36,4 +53,26 @@ export class GeoDataUtil {
     }
     return options;
   }
+
+  /**
+   * Gives the city which contains the given lat, long if it is a supported city
+   * (Richmond, New Orleans, Toledo).
+   */
+  static getCityForLatLong(latString: string | undefined, longString: string | undefined): City | null {
+    const lat = Number(latString);
+    const long = Number(longString);
+    if (!lat || !long) return null;
+
+    let cityForLatLong = null;
+    const latLong: LngLatLike = { lng: long, lat: lat };
+    CITY_BOUNDS.forEach((city, bound) => {
+      if (bound.contains(latLong)) {
+        cityForLatLong = city;
+        return;
+      }
+    });
+    return cityForLatLong;
+  }
 }
+
+export { TOLEDO_BOUNDS };

--- a/client/src/util/geo_data_util.ts
+++ b/client/src/util/geo_data_util.ts
@@ -2,9 +2,8 @@ import { City, GeoData } from '@/model/states/model/geo_data';
 import { ZoomLevel } from '@/model/states/model/map_data';
 import { LngLatBounds, LngLatLike } from 'mapbox-gl';
 
-// Define Toledo geometry bounding box to restrict parcel data layer to Toledo.
-// This is needed because we only have parcel-level predictions for Toledo, so this data layer will
-// be empty outside of these boundaries.
+// Define bounding box geometries for supporting cities. This is used to display lead service line
+// replacement information for cities for which we have information for.
 const NEW_ORLEANS_BOUNDS =
   new LngLatBounds([[-90.60946799999999, 29.699838], [-89.796438, 30.106005999999997]]);
 const RICHMOND_BOUNDS =

--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -113,6 +113,11 @@ export default defineComponent({
       });
     },
   },
+  watch: {
+    'geoState.geoids': function() {
+      this.showResultSections = !GeoDataUtil.isNullOrEmpty(this.geoState?.geoids);
+    },
+  },
 });
 </script>
 

--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -33,7 +33,7 @@
       :buttonText='Titles.EXPLORE_NATION_WIDE_MAP'
       @onButtonClick='navigateToMapPage'
     />
-    <LslrSection v-if='showLslr' :city='leadDataState?.data?.city' />
+    <LslrSection v-if='showLslrSection' :city='city' />
   </div>
 </template>
 
@@ -46,14 +46,14 @@ import ScorecardSummaryPanel from '../components/ScorecardSummaryPanel.vue';
 import { ScorecardMessages } from '../assets/messages/scorecard_messages';
 import { Titles } from '../assets/messages/common';
 import NationwideMap from '../components/NationwideMap.vue';
-import LslrSection, { LSLR_CITY_LINKS } from '@/components/LslrSection.vue';
+import LslrSection from '@/components/LslrSection.vue';
 import { useSelector } from '@/model/store';
 import { LeadDataState } from '../model/states/lead_data_state';
-import { City } from '../model/states/model/geo_data';
 import { GeoDataState } from '../model/states/geo_data_state';
 import { GeoDataUtil } from '../util/geo_data_util';
 import ScorecardMapSearchBar from '../components/ScorecardMapSearchBar.vue';
 import SidePanel from '../components/SidePanel.vue';
+import { City } from '../model/states/model/geo_data';
 
 /**
  * Container for SearchBar and MapContainer.
@@ -82,10 +82,20 @@ export default defineComponent({
     return {
       ScorecardMessages,
       SCORECARD_BASE,
-      showLslr: false,
       showResultSections: false,
       Titles,
     };
+
+  },
+  computed: {
+    showLslrSection(): boolean {
+      return this.city != City.unknown;
+    },
+    city(): City {
+      const intersectedCity = this.leadDataState?.data?.city
+        ?? GeoDataUtil.getCityForLatLong(this.geoState?.geoids?.lat, this.geoState?.geoids?.long);
+      return intersectedCity ?? City.unknown;
+    },
   },
   methods: {
     async copyToClipboard() {
@@ -101,15 +111,6 @@ export default defineComponent({
       router.push({
         path: '/map',
       });
-    },
-  },
-  watch: {
-    'leadDataState.data.city': function() {
-      const city = this.leadDataState?.data?.city ?? City.unknown;
-      this.showLslr = city != null && LSLR_CITY_LINKS.get(city) != null;
-    },
-    'geoState.geoids': function() {
-      this.showResultSections = !GeoDataUtil.isNullOrEmpty(this.geoState?.geoids);
     },
   },
 });


### PR DESCRIPTION
## Description

Addresses: CTA#5: Display a button to sign up for an LSL replacement in pilot cities (toledo, richmond).

- Add bounding boxes for Richmond + New Orleans to intersect the lat,long with for surfacing lslr in supported cities.
- Capitalize Toledo in parcels import. (Will update dev DB when this is submitted)

### New

- Bounding boxes + getCityForLatLong in geo data util.

### Changed

- showLslrSection logic (From watcher + data variable to computed property)


## Testing and Reviewing

Tested locally in all 3 cities, both addresses and zip codes. Tested outside of those cities too to make sure nothing shows up when there is no result.