### PR TITLE
Cover the entire page with loading element until data is ready.

### DIFF
--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -1,7 +1,8 @@
 <template>
   <div>
+    <!-- Cover the entire page with loading element until data is ready. -->
     <div class='loading' v-if='!showScorecard'>
-      <loading :active='true' :is-full-page='false' color='#2553A0' loader='bars' />
+      <loading :active='true' :is-full-page='false' color='#2553A0' loader='bars' opacity='1' />
     </div>
     <div v-if='showScorecard'>
       <PredictionPanel />


### PR DESCRIPTION
## Description

https://github.com/BlueConduit/open-data-platform/pull/157 made the loading element from https://github.com/BlueConduit/open-data-platform/pull/159 render strangely. 

<img width="550" alt="image" src="https://user-images.githubusercontent.com/4321880/189720350-1e1d35d3-4df7-450e-918a-16a755a75b79.png">

This PR is a quick fix that bumps the opacity up to 100% so it hide any elements while the page loads.

### Changed

- increased loading element opacity.

## Testing and Reviewing

Set networking throttling in dev tools (e.g. mid-tier mobile) to increase the load time. Here's what it looks like on mobile

<img width="550" alt="image" src="https://user-images.githubusercontent.com/4321880/189719978-c86f3f3c-4b22-4b23-aa1f-151b1da1db9c.png">
