### PR TITLE
Call city implementation

### DIFF
--- a/client/src/assets/messages/scorecard_messages.ts
+++ b/client/src/assets/messages/scorecard_messages.ts
@@ -12,6 +12,9 @@ export class ScorecardMessages {
     'The Area Deprivation Index (ADI) is based on a measure created by the Health Resources & ' +
     'Services Administration. It includes factors like income, education, employment, and housing quality.';
   static AVERAGE_INCOME = 'Average income';
+  static CONTACT_YOUR_CITY_HEADER = 'Contact your city';
+  static CONTACT_YOUR_CITY_SUBHEADER = 'Get more information or remediate any lead issues is to ' +
+    'contact your city.';
   static COPY_TO_CLIPBOARD = 'Copy scorecard link';
   static EXPLORE_MAP_PAGE_EXPLAINER =
     'You can learn more about what’s happening in your community, state, ' +

--- a/client/src/components/ContactCitySection.vue
+++ b/client/src/components/ContactCitySection.vue
@@ -22,29 +22,39 @@ import { City } from '../model/states/model/geo_data';
 import { defineComponent, PropType } from 'vue';
 import { ScorecardMessages } from '../assets/messages/scorecard_messages';
 
-interface CityInformation {
+interface CityContactInfo {
   name: City;
   website: string;
   phoneNumber: string;
 }
 
-const CITY_INFO: CityInformation[] = [
-  {
-    name: City.newOrleans,
-    website: 'https://www.swbno.org/DrinkingWater/LeadAwareness',
-    phoneNumber: '(504) 529-2837',
-  },
-  {
-    name: City.richmond,
-    website: 'https://www.vdh.virginia.gov/richmond-city/healthy-homes',
-    phoneNumber: '(804) 205-3726',
-  },
-  {
-    name: City.toledo,
-    website: 'https://toledo.oh.gov/residents/water/lead-service-lines',
-    phoneNumber: '(419)-936-2020',
-  },
-];
+// TODO: Move to table in DB if we get more entries.
+const CITY_INFO: Map<City, CityContactInfo> = new Map([
+  [
+    City.newOrleans,
+    {
+      name: City.newOrleans,
+      website: 'https://www.swbno.org/DrinkingWater/LeadAwareness',
+      phoneNumber: '(504) 529-2837',
+    },
+  ],
+  [
+    City.richmond,
+    {
+      name: City.richmond,
+      website: 'https://www.vdh.virginia.gov/richmond-city/healthy-homes',
+      phoneNumber: '(804) 205-3726',
+    },
+  ],
+  [
+    City.toledo,
+    {
+      name: City.toledo,
+      website: 'https://toledo.oh.gov/residents/water/lead-service-lines',
+      phoneNumber: '(419)-936-2020',
+    },
+  ],
+]);
 
 /**
  * Component for the contact city section of scorecard.
@@ -56,6 +66,7 @@ export default defineComponent({
   props: {
     city: {
       type: String as PropType<City>,
+      default: City.unknown,
     },
   },
   data() {
@@ -65,12 +76,11 @@ export default defineComponent({
   },
   computed: {
     website(): string {
-      const currentCity = CITY_INFO.filter((currentCity) => currentCity.name == this.city)[0];
-      return currentCity?.website ?? '';
+      return CITY_INFO.get(this.city)?.website ?? '';
     },
     phoneNumber(): string {
-      const currentCity = CITY_INFO.filter((currentCity) => currentCity.name == this.city)[0];
-      return currentCity?.phoneNumber ?? '';
+      return CITY_INFO.get(this.city)?.phoneNumber ?? '';
+
     },
   },
 });

--- a/client/src/components/ContactCitySection.vue
+++ b/client/src/components/ContactCitySection.vue
@@ -1,19 +1,17 @@
 <template>
   <div>
-    <!--    TODO put messages in constants-->
     <div class='header-section'>
-      <div class='h1-header'>Contact your city</div>
-      <div class='h2-header'>
-        Get more information or remediate any lead issues is to contact your
-        city.
+      <div class='h2-header-large'>
+        {{ MESSAGES.CONTACT_YOUR_CITY_HEADER }}
+      </div>
+      <div>
+        {{ MESSAGES.CONTACT_YOUR_CITY_SUBHEADER }}
       </div>
     </div>
     <div class='city-information'>
-      <div class='h2-header-large'> {{ this.city }}</div>
-      <a class='h2-header-large' :href='website' target='_blank'>
-        {{ website }}
-      </a>
-      <div class='h2-header-large'> Tel: {{ phoneNumber }}</div>
+      <div class='h2-header'> {{ this.city }}</div>
+      <a class='h2-header' :href='website' target='_blank'>{{ website }}</a>
+      <div class='h2-header'> Tel: {{ phoneNumber }}</div>
     </div>
   </div>
 </template>
@@ -22,6 +20,7 @@
 
 import { City } from '../model/states/model/geo_data';
 import { defineComponent, PropType } from 'vue';
+import { ScorecardMessages } from '../assets/messages/scorecard_messages';
 
 interface CityInformation {
   name: City;
@@ -47,6 +46,11 @@ const CITY_INFO: CityInformation[] = [
   },
 ];
 
+/**
+ * Component for the contact city section of scorecard.
+ *
+ * Only shows up when result is in a supported city.
+ */
 export default defineComponent({
   name: 'ContactCitySection',
   props: {
@@ -54,14 +58,19 @@ export default defineComponent({
       type: String as PropType<City>,
     },
   },
+  data() {
+    return {
+      MESSAGES: ScorecardMessages,
+    };
+  },
   computed: {
     website(): string {
       const currentCity = CITY_INFO.filter((currentCity) => currentCity.name == this.city)[0];
-      return currentCity.website;
+      return currentCity?.website ?? '';
     },
     phoneNumber(): string {
       const currentCity = CITY_INFO.filter((currentCity) => currentCity.name == this.city)[0];
-      return currentCity.phoneNumber;
+      return currentCity?.phoneNumber ?? '';
     },
   },
 });

--- a/client/src/components/ContactCitySection.vue
+++ b/client/src/components/ContactCitySection.vue
@@ -1,0 +1,67 @@
+<template>
+  <div>
+    <!--    TODO put messages in constants-->
+    <div>Contact your city</div>
+    <div>
+      Get more information or remediate any lead issues is to contact your city.
+    </div>
+    <div class='city-information'>
+      <p> {{ this.city }}</p>
+      <p> {{ website }}</p>
+      <p> {{ phoneNumber }}</p>
+    </div>
+  </div>
+</template>
+
+<script lang='ts'>
+
+import { City } from '../model/states/model/geo_data';
+import { defineComponent, PropType } from 'vue';
+
+interface CityInformation {
+  name: City;
+  website: string;
+  phoneNumber: string;
+}
+
+const CITY_INFO: CityInformation[] = [
+  {
+    name: City.newOrleans,
+    website: 'https://www.swbno.org/DrinkingWater/LeadAwareness',
+    phoneNumber: '(504) 529-2837',
+  },
+  {
+    name: City.richmond,
+    website: 'https://www.vdh.virginia.gov/richmond-city/healthy-homes/#:~:text=The%20Lead%20Safe%20Program%20provides,)%20205%2D3726%20for%20information.',
+    phoneNumber: '(804) 205-3726',
+  },
+  {
+    name: City.toledo,
+    website: 'https://toledo.oh.gov/residents/water/lead-service-lines',
+    phoneNumber: '(419)-936-2020',
+  },
+];
+
+export default defineComponent({
+  name: 'ContactCitySection',
+  props: {
+    city: {
+      type: String as PropType<City>,
+    },
+  },
+  computed: {
+    website(): string {
+      const currentCity = CITY_INFO.filter((currentCity) => currentCity.name == this.city)[0];
+      return currentCity.website;
+    },
+    phoneNumber(): string {
+      const currentCity = CITY_INFO.filter((currentCity) => currentCity.name == this.city)[0];
+      return currentCity.phoneNumber;
+    },
+  },
+});
+</script>
+
+<style scoped>
+
+</style>

--- a/client/src/components/ContactCitySection.vue
+++ b/client/src/components/ContactCitySection.vue
@@ -1,14 +1,19 @@
 <template>
   <div>
     <!--    TODO put messages in constants-->
-    <div>Contact your city</div>
-    <div>
-      Get more information or remediate any lead issues is to contact your city.
+    <div class='header-section'>
+      <div class='h1-header'>Contact your city</div>
+      <div class='h2-header'>
+        Get more information or remediate any lead issues is to contact your
+        city.
+      </div>
     </div>
     <div class='city-information'>
-      <p> {{ this.city }}</p>
-      <p> {{ website }}</p>
-      <p> {{ phoneNumber }}</p>
+      <div class='h2-header-large'> {{ this.city }}</div>
+      <a class='h2-header-large' :href='website' target='_blank'>
+        {{ website }}
+      </a>
+      <div class='h2-header-large'> Tel: {{ phoneNumber }}</div>
     </div>
   </div>
 </template>
@@ -32,7 +37,7 @@ const CITY_INFO: CityInformation[] = [
   },
   {
     name: City.richmond,
-    website: 'https://www.vdh.virginia.gov/richmond-city/healthy-homes/#:~:text=The%20Lead%20Safe%20Program%20provides,)%20205%2D3726%20for%20information.',
+    website: 'https://www.vdh.virginia.gov/richmond-city/healthy-homes',
     phoneNumber: '(804) 205-3726',
   },
   {
@@ -62,6 +67,14 @@ export default defineComponent({
 });
 </script>
 
-<style scoped>
+<style scoped lang='scss'>
+@import '../assets/styles/global.scss';
+@import '@blueconduit/copper/scss/01_settings/design-tokens';
 
+.city-information {
+  background-color: $light-gold;
+  padding: $spacing-lg;
+  margin-top: $spacing-lg;
+  border-radius: $spacing-xs;
+}
 </style>

--- a/client/src/components/NationwideMap.vue
+++ b/client/src/components/NationwideMap.vue
@@ -99,7 +99,7 @@ export default defineComponent({
     center: {
       // There is no constructor function for a Tuple, so use object here and
       // cast to PropType of a tuple.
-      // See https://vuejs.org/guide/typescript/options-api.html#typing-component-props.
+      // See https://vuejsForg/guide/typescript/options-api.html#typing-component-props.
       type: Object as PropType<[number, number]>,
       default: DEFAULT_LNG_LAT,
     },

--- a/client/src/components/NationwideMap.vue
+++ b/client/src/components/NationwideMap.vue
@@ -99,7 +99,7 @@ export default defineComponent({
     center: {
       // There is no constructor function for a Tuple, so use object here and
       // cast to PropType of a tuple.
-      // See https://vuejsForg/guide/typescript/options-api.html#typing-component-props.
+      // See https://vuejs.org/guide/typescript/options-api.html#typing-component-props.
       type: Object as PropType<[number, number]>,
       default: DEFAULT_LNG_LAT,
     },

--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -54,6 +54,11 @@
       />
 
       <LslrSection v-if='showLslrSection' :city='leadDataState?.data?.city' />
+
+      <ContactCitySection
+        class='section'
+        v-if='showLslrSection'
+        :city='city' />
     </div>
   </div>
 </template>
@@ -79,6 +84,7 @@ import { getParcel, getWaterSystem } from '../model/slices/lead_data_slice';
 import { GeoDataUtil } from '../util/geo_data_util';
 import Loading from 'vue-loading-overlay';
 import 'vue-loading-overlay/dist/vue-loading.css';
+import ContactCitySection from '../components/ContactCitySection.vue';
 
 /**
  * Container for SearchBar and MapContainer.
@@ -86,6 +92,7 @@ import 'vue-loading-overlay/dist/vue-loading.css';
 export default defineComponent({
   name: 'ScorecardView',
   components: {
+    ContactCitySection,
     ActionSection,
     Loading,
     LslrSection,

--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -43,6 +43,11 @@
         </div>
       </div>
 
+      <ContactCitySection
+        class='section'
+        v-if='showLslrSection'
+        :city='city' />
+
       <ScorecardSummaryPanel v-if='showResults' />
 
       <ActionSection
@@ -53,12 +58,8 @@
         @onButtonClick='navigateToMapPage'
       />
 
-      <LslrSection v-if='showLslrSection' :city='leadDataState?.data?.city' />
+      <LslrSection v-if='showLslrSection' :city='city' />
 
-      <ContactCitySection
-        class='section'
-        v-if='showLslrSection'
-        :city='city' />
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Description

Addresses: CTA#2: Display contact info to call the city or water system 

Also fixes bug introduced in https://github.com/BlueConduit/open-data-platform/pull/157 which looks at the parcel city field instead of the computed property for the lslr section. 

### New

- Contact your city section

## Testing and Reviewing

Tested locally and in sandbox: 

[Toledo](https://kailajeter.leadout-sandbox.blueconduit.com/scorecard/address/41.724295,-83.552465) 
[New Orleans](https://kailajeter.leadout-sandbox.blueconduit.com/scorecard/postcode/29.960244,-90.073635)
[Richmond](https://kailajeter.leadout-sandbox.blueconduit.com/scorecard/postcode/37.579738,-77.53986)