### PR TITLE
Fix side panel width

### DIFF
--- a/client/src/components/GeoIdSection.vue
+++ b/client/src/components/GeoIdSection.vue
@@ -44,7 +44,6 @@ export default defineComponent({
 }
 
 .geoid-section {
-  width: 57 * $spacing-xs;
   height: fit-content;
   border: 1px solid $gold;
   border-radius: $spacing-xs;

--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -10,11 +10,18 @@
       <!-- Only display the side-panel, full-width on mobile. -->
       <ScorecardMapSearchBar class='is-hidden-mobile' />
       <div class='columns is-variable is-centered is-gapless'>
-        <div class='column side-panel' v-if='showResults'>
+        <!-- Conditionally use the "side-panel" class to limit column width on desktop only -->
+        <div class='column is-hidden-desktop' v-if='showResults'>
           <div class='section'>
             <SidePanel />
           </div>
         </div>
+        <div class='column is-hidden-touch side-panel' v-if='showResults'>
+          <div class='section'>
+            <SidePanel />
+          </div>
+        </div>
+
         <div class='column is-hidden-mobile'>
           <NationwideMap height='60vh' :enableBasicMap='true' />
         </div>

--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -10,7 +10,7 @@
       <!-- Only display the side-panel, full-width on mobile. -->
       <ScorecardMapSearchBar class='is-hidden-mobile' />
       <div class='columns is-variable is-centered is-gapless'>
-        <div class='column side-panel'>
+        <div class='column side-panel' v-if='showResults'>
           <div class='section'>
             <SidePanel />
           </div>
@@ -42,10 +42,7 @@
         </div>
       </div>
 
-      <ContactCitySection
-        class='section'
-        v-if='showLslrSection'
-        :city='city' />
+      <ContactCitySection class='section' v-if='showLslrSection' :city='city' />
 
       <ScorecardSummaryPanel v-if='showResults' />
 
@@ -58,7 +55,6 @@
       />
 
       <LslrSection v-if='showLslrSection' :city='city' />
-
     </div>
   </div>
 </template>

--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -2,21 +2,20 @@
   <div>
     <!-- Cover the entire page with loading element until data is ready. -->
     <div class='loading' v-if='!showScorecard'>
-      <loading :active='true' :is-full-page='false' color='#2553A0'
-               loader='bars' opacity='1' />
+      <loading :active='true' :is-full-page='false' color='#2553A0' loader='bars' opacity='1' />
     </div>
     <div v-if='showScorecard'>
       <PredictionPanel />
 
       <!-- Only display the side-panel, full-width on mobile. -->
       <ScorecardMapSearchBar class='is-hidden-mobile' />
-      <div class='columns is-variable is-centered'>
-        <div class='column'>
+      <div class='columns is-variable is-centered is-gapless'>
+        <div class='column side-panel'>
           <div class='section'>
             <SidePanel />
           </div>
         </div>
-        <div class='column is-two-thirds is-hidden-mobile'>
+        <div class='column is-hidden-mobile'>
           <NationwideMap height='60vh' :enableBasicMap='true' />
         </div>
       </div>
@@ -58,7 +57,7 @@
   </div>
 </template>
 
-<script lang='ts'>
+<script lang="ts">
 import PredictionPanel from '../components/PredictionPanel.vue';
 import ActionSection from '../components/ActionSection.vue';
 import { defineComponent } from 'vue';
@@ -172,14 +171,14 @@ export default defineComponent({
   watch: {
     // Listen for changes to pws id or lat, long. Once it changes, a new
     // prediction must be fetched.
-    'geoState.geoids': function() {
+    'geoState.geoids': function () {
       this.updateViewWithGeoIds();
     },
   },
 });
 </script>
 
-<style scoped lang='scss'>
+<style scoped lang="scss">
 @import '../assets/styles/global.scss';
 @import '@blueconduit/copper/scss/01_settings/design-tokens';
 @import 'bulma/sass/layout/section.sass';
@@ -189,5 +188,9 @@ export default defineComponent({
 
 .nav-to-map {
   background-color: $light-blue-50;
+}
+
+.side-panel {
+  max-width: 6 * $spacing-xl;
 }
 </style>


### PR DESCRIPTION
## Description

When making the scorecard responsive, the side panel got a dynamic-width, which looks weird on a side screen.

![image](https://user-images.githubusercontent.com/4321880/189755593-069fe2ca-873c-4464-85f1-7e5dfb795c7c.png)

This PR fixes the width.

### Changed

- Side panel has a max-width.
- GeoIdSections have a dynamic width to fill the side panel. Consequently, they are now wider in the mobile view when not constrained next to the map.

## Testing and Reviewing

Locally tested at different screen sizes.

Mobile:

<img width="521" alt="image" src="https://user-images.githubusercontent.com/4321880/189755253-4b76720a-8fe9-42b5-bea2-3eab021859c1.png">

Tablet:

<img width="865" alt="image" src="https://user-images.githubusercontent.com/4321880/189975849-410a3c5b-a49c-4056-bfcd-1a9ba9a791e1.png">

Desktop:

<img width="1618" alt="image" src="https://user-images.githubusercontent.com/4321880/189755280-bbf26987-1640-4fb2-8e1f-e68baab79850.png">
