### PR TITLE
Remove resources link in navbar.

### DIFF
--- a/client/src/components/ResponsiveNav.vue
+++ b/client/src/components/ResponsiveNav.vue
@@ -33,7 +33,8 @@ export default defineComponent({
       [Titles.LEAD_STATUS_TITLE, router.SCORECARD_BASE],
       [Titles.MAP_TITLE, router.MAP_ROUTE_BASE],
       [Titles.ABOUT_TITLE, router.ABOUT_ROUTE],
-      [Titles.RESOURCES_TITLE, router.RESOURCES_ROUTE],
+      // TODO: Re-add the resources link once we have a resources page in Wordpress.
+      // [Titles.RESOURCES_TITLE, router.RESOURCES_ROUTE],
     ];
     return {
       routes,


### PR DESCRIPTION
## Description

Addresses: [Remove resources link in navbar.](https://tables.area120.google.com/table/bX_kMNBW8LA35n6l5Hz_co/row/aubWVjT8XO_0CiSUtKW_Rz)

The resources page doesn't have much right now, so we shouldn't be advertising it. This keeps any other links, such as from the scorecard.

### Removed

- Link in navbar.

## Testing and Reviewing

Local testing.

<img width="514" alt="image" src="https://user-images.githubusercontent.com/4321880/189762858-b1b90b2c-295c-4539-a2ae-4c8eff1e1a5c.png">

<img width="1607" alt="image" src="https://user-images.githubusercontent.com/4321880/189762881-1204e7cc-c5b9-44ff-a770-faa9d24ded64.png">

