### PR TITLE
Make water-systems-imports a bit faster and more reliable

### DIFF
--- a/cdk/src/open-data-platform/data-plane/data-import/write-water-systems-data.handler.ts
+++ b/cdk/src/open-data-platform/data-plane/data-import/write-water-systems-data.handler.ts
@@ -131,7 +131,7 @@ export const handler = geoJsonHandlerFactory(
       rdsDataService,
       rows.map(getTableRowFromRow).filter((row) => row != null) as SqlParametersList[],
     );
-
-    await clusterRows(rdsDataService);
   },
+  async (rdsDataService: RDSDataService) => clusterRows(rdsDataService),
+  1000
 );


### PR DESCRIPTION
## Description

### Use larger batch sizes since it costs us nothing

- From adding some timestamps (preserved in this PR) and inspecting the logs it appears that each insertion operation takes around 10 seconds, irrespective of whether we're inserting [10 rows](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Flambda$252Frsrogers-OpenDataPlatform-DataImportStackwritewate-bnHStk6DBLka/log-events/2022$252F09$252F12$252F$255B$2524LATEST$255Dfa1a1c00f74345a0bd17975e438e2473) or [1000 rows](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Flambda$252Frsrogers-OpenDataPlatform-DataImportStackwritewate-bnHStk6DBLka/log-events/2022$252F09$252F12$252F$255B$2524LATEST$255Dca5b79ca729d4b8aa022021f0f0dd40b). 
- It therefore makes sense to use a much larger batch size for insertions
- This PR makes the batch size optionally overridable, and has water-systems imports default to 1k rows per batch.
- This drops the average runtime from ~45 seconds to ~25. The difference is not 10x, since all this still happens in parallel.

### I was clustering after each insertion, forcing insertions to happen serially

- Clustering rows requires a table-level lock, therefore clustering after each insertion forces insertions to happen serially.
- This is not too bad with large batch sizes, but with 5k insertions, it increases the average insertion time from ~10 seconds to ~12 seconds.
- It is difficult to know what the final runtime impact of this is because the lambda returns early with a generic `Network Error` if things take much longer than a minute. 
  - I logged heap usage to see if we're out of memory but heap usage never gets above 1GB and I'd allocated 10GB. 
- This PR updates `geoJsonHandlerFactory` to accept an optional `finalCallback`, and does its clustering work _after_ all insertions are complete.

### We don't have any backpressure mechanism

- From reading the logs, we seem to be doing the following:
  - Immediately kick off ~5k promises (as fast as we can download the file), each attempting to insert 10 rows of data
  - Some of these fail, seemingly because we're understandably overwhelming Aurora
  - For each failure, we kick of 10 more promises, each attempting to insert 1 row of data
- This is going to add a lot of pressure to Aurora, since the write throughput of Aurora is almost certainly slower than the network throughput when fetching stuff from S3.
- As the water-systems table gets bigger (assuming it does) this is going to cause more failures and out-of-memory errors
- We should probably write a `throttler`, that ensures no more than `x` concurrent calls are made to Aurora at any given time.


Addresses: [N/A]()

- makes the batch size optionally overridable, and has water-systems imports default to 1k rows per batch.
- updates `geoJsonHandlerFactory` to accept an optional `finalCallback`, and does its clustering work _after_ all insertions are complete.

### New

- `geoJsonHandlerFactory` now takes two additional (optional) arguments
  - `finalCallback`, invoked after all rows are handled
  - `batchSizeOverride`, to override the batch size for handling rows with

### Changed

- The default batch size for water-systems imports is now 1000 rows
- Clustering of rows now happens _after_ all rows are written, not after each batch is written

### Removed

- N/A

## Testing and Reviewing

- Run the import. See success logs [here](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Flambda$252Frsrogers-OpenDataPlatform-DataImportStackwritewate-bnHStk6DBLka/log-events/2022$252F09$252F13$252F$255B$2524LATEST$255D21c050e912af40ca8e3fb4a9e519659e)
