### PR TITLE
Reorder sections based on user feedback

### DIFF
--- a/client/src/assets/messages/scorecard_messages.ts
+++ b/client/src/assets/messages/scorecard_messages.ts
@@ -6,11 +6,12 @@ export class ScorecardMessages {
   static ADDITIONAL_STEPS_SUBHEADER =
     'Worried about your lead risk status? One of the best ways to remedy your ' +
     'water supply is to order a filter.';
-  static AREA_DEPRIVATION_INDEX = 'Area Deprivation Index';
+  static AREA_DEPRIVATION_INDEX = 'Area Deprivation';
   static AREA_DEPRIVATION_INDEX_EXPLAINED =
-    'The Area Deprivation Index (ADI) is based on a measure created by the Health Resources & ' +
-    'Services Administration. It includes factors like income, education, employment, and housing quality.';
-  static AVERAGE_INCOME = 'Average income';
+    'The ADI is based on 17 variables that describe socioeconomic disadvantage ' +
+    'based on income, education, household characteristics, and housing created ' +
+    'by the Health Resources and Services Administration (HRSA).';
+  static AVERAGE_INCOME = 'Income level';
   static CONTACT_YOUR_CITY_HEADER = 'Contact your city';
   static CONTACT_YOUR_CITY_SUBHEADER =
     'Get more information or remediate any lead issues is to contact your city.';
@@ -31,11 +32,16 @@ export class ScorecardMessages {
   static HIGHLY_DISADVANTAGED = 'Highly disadvantaged';
   static NOT_LIKELY = 'not likely';
   static HIGHER_INCOME = 'Higher income';
-  static HOME_AGE = 'Average home age';
+  static HOME_AGE = 'Age of Your Home';
   static HOME_AGE_EXPLAINED =
-    'The year homes were built influences the likelihood they are constructed with lead pipes';
+    'Older homes are more likely to be connected to lead water pipes than newer ' +
+    'homes. We use the average home age in your zip code to help determine your status. ';
   static INCOME_LEVEL = 'Average income level';
-  static INCOME_LEVEL_EXPLAINED = 'Income levels correlate to the likelihood of lead.';
+  static INCOME_LEVEL_EXPLAINED =
+    'Income levels are also a determining factor that ' +
+    'could indicate the possibility of lead in a neighborhood or zip code.\n \n' +
+    'This information was taken from U.S. Census data and is measured by zip code ' +
+    'and not this specific address.';
   static LEAD_LIKELIHOOD_EXPLAINED =
     'Based on age of homes, historical service line data, and information ' +
     'collected from your utility and other sources';

--- a/client/src/assets/messages/scorecard_messages.ts
+++ b/client/src/assets/messages/scorecard_messages.ts
@@ -2,11 +2,10 @@
  * Text to use on the scorecard summary page.
  */
 export class ScorecardMessages {
-  static ADDITIONAL_STEPS_HEADER = 'Additional steps you can take';
+  static ADDITIONAL_STEPS_HEADER = 'Protect your home';
   static ADDITIONAL_STEPS_SUBHEADER =
-    'The fastest way to protect your home ' +
-    'is to use a water filter. If you don’t already own one, learn more about ' +
-    'things to consider when choosing a filter that fits your needs.';
+    'Worried about your lead risk status? One of the best ways to remedy your ' +
+    'water supply is to order a filter.';
   static AREA_DEPRIVATION_INDEX = 'Area Deprivation Index';
   static AREA_DEPRIVATION_INDEX_EXPLAINED =
     'The Area Deprivation Index (ADI) is based on a measure created by the Health Resources & ' +
@@ -16,7 +15,7 @@ export class ScorecardMessages {
   static CONTACT_YOUR_CITY_SUBHEADER =
     'Get more information or remediate any lead issues is to contact your city.';
   static COPIED_TO_CLIPBOARD = 'Copied!';
-  static COPY_TO_CLIPBOARD = 'Copy scorecard link';
+  static COPY_TO_CLIPBOARD = 'Copy link to share';
   static EXPLORE_MAP_PAGE_EXPLAINER =
     'You can learn more about what’s happening in your community, state, ' +
     'or the United States by exploring the Nationwide Map. ';
@@ -54,7 +53,7 @@ export class ScorecardMessages {
   static SHARE_LEAD_OUT_SUBHEADER = 'Help others know their lead status through LeadOut.';
   static SOMEWHAT_DISADVANTAGED = 'Somewhat disadvantaged';
   static SOMEWHAT_LIKELY = 'somewhat likely';
-  static TAKE_ACTION_HEADER = 'Take action';
+  static TAKE_ACTION_HEADER = "Here's what you can do today";
   static WANT_TO_KNOW_MORE = 'Want to know more?';
   static WATER_SYSTEM_DESCRIPTION =
     'This is the water system which owns the service lines that provide water to this area.';

--- a/client/src/components/scorecard_page/ScorecardSummaryPanel.vue
+++ b/client/src/components/scorecard_page/ScorecardSummaryPanel.vue
@@ -156,7 +156,7 @@ export default defineComponent({
 @import 'bulma/sass/elements/container';
 
 .section {
-  background-color: $light-blue;
+  background-color: $navy-blue;
   color: $white;
 }
 

--- a/client/src/components/scorecard_page/ScorecardSummaryRow.vue
+++ b/client/src/components/scorecard_page/ScorecardSummaryRow.vue
@@ -67,7 +67,7 @@ export default defineComponent({
 }
 
 .comparison-value {
-  color: $warm-grey-800;
+  color: $text_white;
   font-weight: 600;
 }
 

--- a/client/src/views/ScorecardView.vue
+++ b/client/src/views/ScorecardView.vue
@@ -29,6 +29,7 @@
           <NationwideMap height='70vh' :enableBasicMap='true' />
         </div>
       </div>
+      <ScorecardSummaryPanel v-if='showResults' />
       <div class='section has-text-centered' v-if='showResults'>
         <div class='h1-header-large'>
           {{ ScorecardMessages.TAKE_ACTION_HEADER }}
@@ -51,13 +52,6 @@
         </div>
       </div>
       <ContactCitySection class='section' v-if='showLslrSection' :city='city' />
-      <ScorecardSummaryPanel v-if='showResults' />
-      <ActionSection
-        class='section'
-        :header='ScorecardMessages.ADDITIONAL_STEPS_HEADER'
-        :subheader='ScorecardMessages.ADDITIONAL_STEPS_SUBHEADER'
-        :buttonText='ScorecardMessages.RESEARCH_WATER_FILTERS'
-        @onButtonClick='navigateToResourcePage' />
       <ActionSection
         class='section nav-to-map'
         :header='ScorecardMessages.WANT_TO_KNOW_MORE'


### PR DESCRIPTION
## Description

Addresses: Reorder scorecard sections based on user testing feedback

"Moves Understanding your Statu " above "Here's what you can do" in accordance with new [mocks](https://www.figma.com/file/0LGxjZnPD3N0dCqHv8LRr6/NW-Map-Design-System-WIP?node-id=1057%3A6040) / user feedback

### Changed

Copy inside these sections to reflect new text
Removed double "Actions to take" section

## Testing and Reviewing

![image](https://user-images.githubusercontent.com/7783393/191788140-5a427835-7e4d-4ed8-a298-c218171da65b.png)