### PR TITLE
Use common messages file in the canaries

### DIFF
--- a/cdk/src/monitoring/synthetics.handler.js
+++ b/cdk/src/monitoring/synthetics.handler.js
@@ -59,7 +59,7 @@ exports.handler = async function () {
     await page.waitForSelector('.geoid-section');
     // Check for CTA presence.
     await waitForString(page, 'Research water filters');
-    await waitForString(page, 'Copy scorecard link');
+    await waitForString(page, 'Copy link to share');
     // Check for score details presence.
     await waitForString(page, 'Understanding your score');
     await page.screenshot();

--- a/cdk/src/monitoring/synthetics.handler.ts
+++ b/cdk/src/monitoring/synthetics.handler.ts
@@ -1,5 +1,11 @@
 const synthetics = require('Synthetics');
 const syntheticsConfiguration = synthetics.getConfiguration();
+const log = require('SyntheticsLogger');
+
+// This is implicitly imported in synthetics.ts. TS doesn't like that, so ignore the error that this
+// doesn't exist.
+// @ts-ignore
+const scorecardMessages = ScorecardMessages;
 
 /**
  * Helper function for searching the entire page for a string. Returns if the string was found
@@ -10,7 +16,7 @@ const syntheticsConfiguration = synthetics.getConfiguration();
  * @param s - String to search
  * @returns
  */
-const waitForString = async (page, s) =>
+const waitForString = async (page: { waitForFunction: (arg0: string) => any }, s: string) =>
   await page.waitForFunction(`document.querySelector("body").innerText.includes("${s}")`);
 
 exports.handler = async function () {
@@ -54,14 +60,14 @@ exports.handler = async function () {
 
   await synthetics.executeStep('viewScorecard', async function () {
     // Check for prediction presence.
-    await waitForString(page, 'Low likelihood');
+    await waitForString(page, scorecardMessages.LOW_LIKELIHOOD);
     // Check for side panel presence.
     await page.waitForSelector('.geoid-section');
     // Check for CTA presence.
-    await waitForString(page, 'Research water filters');
-    await waitForString(page, 'Copy link to share');
+    await waitForString(page, scorecardMessages.RESEARCH_WATER_FILTERS);
+    await waitForString(page, scorecardMessages.COPY_TO_CLIPBOARD);
     // Check for score details presence.
-    await waitForString(page, 'Understanding your score');
+    await waitForString(page, scorecardMessages.SCORECARD_SUMMARY_PANEL_HEADER(null));
     await page.screenshot();
   });
 };


### PR DESCRIPTION
## Description

Addresses: [Canaries](https://tables.area120.google.com/table/bX_kMNBW8LA35n6l5Hz_co/row/826xIGWGqdF62fj6Icp__4)

The canaries started failing after https://github.com/BlueConduit/open-data-platform/pull/186 changed a string. Since the canary handler is a single JS blob, this PR does some string manipulation to combine the handler with the messages file so that the handler can reference the same `ScorecardMessages` as the client.

### Changed

- Semi-hacky transpiling method of importing the handler.
- Replaced strings in the handler with references to `ScorecardMessages` properties.

## Testing and Reviewing

The [canaries](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#synthetics:canary/detail/monitoringsynth81c9cc) pass in my sandbox!

<img width="941" alt="image" src="https://user-images.githubusercontent.com/4321880/191861040-1e37f315-7b24-484b-adf7-5a425266c957.png">
