### PR TITLE
Name monitoring stages uniquely.

### DIFF
--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -23,3 +23,4 @@ jobs:
       # CDK.
       - run: npm --prefix cdk ci
       - run: npm --prefix cdk run test
+      - run: npm --prefix cdk run pipeline-synth

--- a/cdk/src/pipeline/pipeline-stack.ts
+++ b/cdk/src/pipeline/pipeline-stack.ts
@@ -75,7 +75,9 @@ export class PipelineStack extends Stack {
     );
 
     pipeline.addStage(
-      new MonitoringStage(this, 'Dev', {
+      // This must have a unique name from the `Dev` stage. It also must end in `Dev` so stacks have
+      // a similar name to other Dev stacks.
+      new MonitoringStage(this, 'Monitoring-Dev', {
         env: { account: '036999211278', region: 'us-east-2' },
         tags: { Project: util.projectName, Environment: util.EnvType.Development },
         envType: util.EnvType.Development,
@@ -114,7 +116,7 @@ export class PipelineStack extends Stack {
     );
 
     pipeline.addStage(
-      new MonitoringStage(this, 'Prod', {
+      new MonitoringStage(this, 'Monitoring-Prod', {
         env: { account: '530942487205', region: 'us-east-2' },
         tags: { Project: util.projectName, Environment: util.EnvType.Production },
         envType: util.EnvType.Production,


### PR DESCRIPTION
## Description

https://github.com/BlueConduit/open-data-platform/pull/195 broke the pipeline with:

> Error: There is already a Construct with name 'Dev' in PipelineStack [OpenDataPlatformPipeline]

This PR gives the monitoring stacks a unique name.

## Testing and Reviewing

`npm run pipeline-synth` succeeds. I forgot to test that before, so I added it as a pre-merge action too. This would have caught the bug, since this command currently fails on `main`.

But we won't really know until the pipeline runs.