### PR TITLE
Remove unused county relation.

### DIFF
--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -241,15 +241,13 @@ CREATE INDEX IF NOT EXISTS epa_violations_state_census_geo_id_idx ON epa_violati
 CREATE OR REPLACE VIEW violation_counts AS
 SELECT pws_id,
        epa_violations.state_census_geo_id,
-       epa_violations.county_census_geo_id,
        geom,
        COUNT(violation_id) AS violation_count
 FROM epa_violations
          JOIN water_systems USING (pws_id)
 GROUP BY pws_id,
          geom,
-         epa_violations.state_census_geo_id,
-         epa_violations.county_census_geo_id;
+         epa_violations.state_census_geo_id;
 
 -- Parcel-level data
 


### PR DESCRIPTION
## Description

Addresses: [bug](https://tables.area120.google.com/table/bX_kMNBW8LA35n6l5Hz_co/row/8wdWw0-5Een3cF8LSrWOi7)

The prod import was failing since this column doesn't exist: https://lslr.slack.com/archives/C03D5199TLG/p1663692083890779

### Changed

- Removed `county_census_geo_id` column.

## Testing and Reviewing

This actually fails on DBs that already have the view: `cannot drop columns from view `. So I'm keeping this as a draft.