### PR TITLE
Geoid in violations

### DIFF
--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -174,20 +174,6 @@ CREATE TABLE IF NOT EXISTS state_demographics
 );
 CREATE INDEX IF NOT EXISTS state_demographics_geom_idx ON state_demographics USING GIST (geom);
 
-CREATE TABLE IF NOT EXISTS county_demographics
-(
-    census_geo_id         varchar(255) NOT NULL,
-    name                  varchar(255) NOT NULL,
-    black_population      real,
-    white_population      real,
-    total_population      real,
-    under_five_population real,
-    poverty_population    real,
-    geom                  geometry(Geometry, 3857),
-    PRIMARY KEY (census_geo_id)
-);
-CREATE INDEX IF NOT EXISTS county_demographics_geom_idx ON county_demographics USING GIST (geom);
-
 -- Water-system-level data
 
 CREATE TABLE IF NOT EXISTS water_systems

--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -370,7 +370,6 @@ FROM counties
 GROUP BY counties.census_geo_id, counties.name, counties.geom
 ON CONFLICT (census_geo_id) DO NOTHING;
 
-
 --- Tileserver function definitions.
 
 CREATE OR REPLACE FUNCTION public.demographics_function_source(z integer,

--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -130,12 +130,10 @@ CREATE TABLE IF NOT EXISTS demographics
     black_population      real,
     white_population      real,
     state_census_geo_id   varchar(255) NOT NULL references states (census_geo_id),
-    county_census_geo_id  varchar(255) NOT NULL references counties (census_geo_id),
     geom                  GEOMETRY(Geometry, 4326),
     PRIMARY KEY (census_geo_id)
 );
 CREATE INDEX IF NOT EXISTS demographics_state_census_geo_id_idx ON demographics (state_census_geo_id);
-CREATE INDEX IF NOT EXISTS demographics_county_census_geo_id_idx ON demographics (county_census_geo_id);
 CREATE INDEX IF NOT EXISTS demographics_geom_idx ON demographics USING GIST (geom);
 
 --- Tables related to U.S. demographic information.
@@ -241,15 +239,13 @@ CREATE INDEX IF NOT EXISTS epa_violations_state_census_geo_id_idx ON epa_violati
 CREATE OR REPLACE VIEW violation_counts AS
 SELECT pws_id,
        epa_violations.state_census_geo_id,
-       epa_violations.county_census_geo_id,
        geom,
        COUNT(violation_id) AS violation_count
 FROM epa_violations
          JOIN water_systems USING (pws_id)
 GROUP BY pws_id,
          geom,
-         epa_violations.state_census_geo_id,
-         epa_violations.county_census_geo_id;
+         epa_violations.state_census_geo_id;
 
 -- Parcel-level data
 

--- a/cdk/src/open-data-platform/data-plane/schema/schema.sql
+++ b/cdk/src/open-data-platform/data-plane/schema/schema.sql
@@ -351,23 +351,6 @@ FROM states
 GROUP BY states.census_geo_id, states.name, states.geom
 ON CONFLICT (census_geo_id) DO NOTHING;
 
-INSERT INTO county_demographics(census_geo_id, name, geom, black_population,
-                                white_population, total_population,
-                                under_five_population, poverty_population)
-SELECT counties.census_geo_id            as census_geo_id,
-       counties.name                     AS name,
-       ST_Transform(counties.geom, 3857) AS geom,
-       SUM(black_population)             AS black_population,
-       SUM(white_population)             AS white_population,
-       SUM(total_population)             AS total_population,
-       SUM(under_five_population)        AS under_five_population,
-       SUM(poverty_population)           AS poverty_population
-FROM counties
-         LEFT JOIN demographics
-                   ON demographics.county_census_geo_id = counties.census_geo_id
-GROUP BY counties.census_geo_id, counties.name, counties.geom
-ON CONFLICT (census_geo_id) DO NOTHING;
-
 --- Tileserver function definitions.
 
 CREATE OR REPLACE FUNCTION public.demographics_function_source(z integer,


### PR DESCRIPTION
Remove county from violation_counts view and add population of state census geo id to violations handler.

Tested in sandbox: https://kailajeter.leadout-sandbox.blueconduit.com/map?layer=epa-lead-and-copper-violations-by-water-system 
