### PR TITLE
Document how to add a unit or integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Technical guides:
 
 - [**Getting Started**](docs/getting-started.md)
 - [Operational Playbook](docs/operational-playbook.md)
+- [Writing Tests](docs/writing-tests.md)
 
 Designs documents:
 

--- a/docs/operational-playbook.md
+++ b/docs/operational-playbook.md
@@ -59,11 +59,10 @@ existing data and re-importing:
 
 ### Deploying a code change
 
-<!-- TODO: Add a link to a doc describing the release process once written. -->
-
 Code changes are deployed to the dev and prod environments automatically after a PR is merged into
-the GitHub repository. No further manual action is required and the deployment process can be
-followed on the
+the GitHub repository
+([design](https://docs.google.com/document/d/1zZxCoXx5JzLXTOGVdvC4s8H-r82DFjfmNU-dmFPAQVI/edit#heading=h.bsmnc9iehgn)).
+No further manual action is required and the deployment process can be followed on the
 [pipeline dashboard](https://us-east-2.console.aws.amazon.com/codesuite/codepipeline/pipelines/OpenDataPlatform/view?region=us-east-2).
 
 ### Rolling back a code change

--- a/docs/operational-playbook.md
+++ b/docs/operational-playbook.md
@@ -48,8 +48,8 @@ and add a test for your change before implementing it)
 ### Testing a data or import lambda change
 
 Data is static after being imported. Changes to the data or its
-[import lambdas](../cdk/bin/src/open-data-platform/data-plane/data-import/) require removing
-existing data and re-importing:
+[import lambdas](../cdk/src/open-data-platform/data-plane/data-import/) require removing existing
+data and re-importing:
 
 1. Log into the AWS account for the environment.
 1. Open the [query editor](#querying-the-db) and drop the table(s) that you want to test.

--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -1,0 +1,73 @@
+# Writing Tests
+
+## Client
+
+Client tests are written in [Vitest](https://vitest.dev/guide/) and are defined within the directory
+of the code they test ([example](../client/src/api/__tests__)).
+
+To add a test:
+
+1. Create a `__tests__/${filename}.test.ts` file in the directory of the code under test.
+1. Write [`test`](https://vitest.dev/api/#test) cases within that file.
+1. [Execute](./operational-playbook.md#testing-a-code-change) the test to ensure it passes.
+
+## CDK
+
+CDK tests are written in [Jest](https://jestjs.io/docs/getting-started) and are defined centrally in
+a [`cdk.test.ts`](../cdk/test/cdk.test.ts) file.
+
+To add a test:
+
+1. Write a [`test`](https://jestjs.io/docs/api#testname-fn-timeout) for the code under test.
+1. [Execute](./operational-playbook.md#testing-a-code-change) the test to ensure it passes.
+
+When adding a new CloudFormation resource (which most things in the CDK are), add a presence check
+to the test suite:
+
+1. If there is a new stack, instantiate it in the `beforeEach` prep step.
+1. Identify the AWS resource type.
+   1. You can view a list of resources types in the [`cdk.out/`](../cdk/cdk.out/) dir.
+   1. You can also reference a
+      [list of resource types here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html).
+1. Add an assertion for presence of the resource:
+
+   ```typescript
+   ${Stack Name}Template.hasResourceProperties(
+     ${Resource Type},
+     ${Any properties you want to assert}
+   )
+   ```
+
+## Canaries
+
+Canaries are integration tests that run in AWS. They are written with [Puppeteer](https://pptr.dev/)
+and are defined centrally in [`synthetics.handler.ts`](../cdk/src/monitoring/synthetics.handler.ts).
+These tests cover full user journeys and simulate a user interacting with the web interface.
+
+### Writing a new test
+
+In contrast to the other test types above, there isn't an explicit definition of individual `test`s
+in the canary code. Instead, all tests should run in the same handler instance. To add a new test:
+
+1. Create a new `synthetics.executeStep` that uses
+   [`page.goto`](https://pptr.dev/api/puppeteer.page.goto) to open the initial page for the test.
+1. Use the Puppeteer API to add interactions to the page.
+1. (Optionally) Add [`page.screenshot`](https://pptr.dev/api/puppeteer.page.screenshot) calls to
+   visually log the page state at various points in the test.
+1. [Execute](./operational-playbook.md#testing-a-code-change) the test to ensure it passes.
+
+### Referencing external code
+
+Canaries can only execute code that is contained within the handler file. Since we would like to
+reference other files, we use [`compileHandlerString`](..cdk/src/monitoring/synthetics.ts) to
+transpile them into a single file. To add more files to the handler:
+
+1. Add the path to the `compileHandlerString` call in the `canary` definition.
+1. Add a `ts-ignore` to the variable you would like to reference. For example:
+
+   ```typescript
+   // @ts-ignore
+   const scorecardMessages = ScorecardMessages; // From scorecard_messages.ts
+   ```
+
+1. Use the newly-defined variable in the handler.

--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -26,7 +26,8 @@ to the test suite:
 
 1. If there is a new stack, instantiate it in the `beforeEach` prep step.
 1. Identify the AWS resource type.
-   1. You can view a list of resources types in the [`cdk.out/`](../cdk/cdk.out/) dir.
+   1. You can view a list of resources types in the [`cdk.out/`](../cdk/cdk.out/) dir. (this is only
+      available after running `cdk synth` or `cdk deploy` locally)
    1. You can also reference a
       [list of resource types here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html).
 1. Add an assertion for presence of the resource:


### PR DESCRIPTION
## Description

Addresses: [Document how to add a unit or integration test](https://tables.area120.google.com/table/bX_kMNBW8LA35n6l5Hz_co/row/boG3sZPFRyPat4NLJcK_u8)

This adds a few brief guides on how we wrote tests.

## Testing and Reviewing

You can see it rendered [here](https://github.com/BlueConduit/open-data-platform/blob/docs/test/docs/writing-tests.md).