### PR TITLE
Cut much of the bake steps from the release pipeline.

### DIFF
--- a/cdk/src/pipeline/pipeline-stack.ts
+++ b/cdk/src/pipeline/pipeline-stack.ts
@@ -8,19 +8,10 @@ import * as util from '../util';
 import { MonitoringStage, OpenDataPlatformStage } from './stage';
 import { BuildSpec, LinuxBuildImage } from 'aws-cdk-lib/aws-codebuild';
 
-const DEV_BAKE_DURATION_SECS = 20 * 60; // 20 minutes, so ensure the canary runs at least once.
-const PROD_BAKE_DURATION_HOURS = 12;
-const PROD_RELEASE_TIME = '09:00'; // 9 am local (Eastern) time.
+const PROD_BAKE_DURATION_HOURS = 4;
 const CODE_REPO = 'BlueConduit/open-data-platform';
 const CODE_CONNECTION_ARN =
   'arn:aws:codestar-connections:us-east-2:223904267317:connection/cf8a731a-3a36-4e74-ac7f-d93604fd258e';
-// Then check there are no open alarms for dev. This ignores alarms named with
-// "TargetTracking" because those are automatically created by AWS for auto-scaling,
-// which shouldn't affect the release.
-const CHECK_DEV_ALARMS_SCRIPT =
-  "if [[ $( aws cloudwatch describe-alarms --query 'MetricAlarms[?contains(AlarmName, `" +
-  `Dev-${util.projectName}` +
-  "`) == `true` && StateValue!=`OK` && !contains(AlarmName, `TargetTracking`)]' --output text) ]]; then exit 1; fi";
 
 export class PipelineStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
@@ -103,18 +94,6 @@ export class PipelineStack extends Stack {
         tags: { Project: util.projectName, Environment: util.EnvType.Development },
         envType: util.EnvType.Development,
       }),
-      {
-        // Bake the release in dev before deploying to prod, to catch any problems early.
-        post: [
-          new pipelines.ShellStep('BakeStep', {
-            commands: [
-              // Bake a minimum of this duration before calling the stage a success.
-              `sleep ${DEV_BAKE_DURATION_SECS}`,
-              CHECK_DEV_ALARMS_SCRIPT,
-            ],
-          }),
-        ],
-      },
     );
 
     pipeline.addStage(
@@ -131,19 +110,22 @@ export class PipelineStack extends Stack {
       }),
     );
 
-    /* TODO: Consider splitting prod out into its own pipeline.
+    /* TODO: Split prod out into its own pipeline or use CodeDeploy.
      *
      * The prod deployment runs on a different schedule than dev [1]. We chose to use one pipeline
      * for both environments for implementation/ops simplicity. However, this doesn't actually
      * implement a "nightly" release since multiple prod releases could happen within a given day.
      *
+     * We tried implementing a schedule and alarm check in ShellSteps [2], but CodeBuild doesn't
+     * have easy access to the alarm data from other accounts and times out after 1 hour.
+     *
      * [1] https://docs.google.com/document/d/1zZxCoXx5JzLXTOGVdvC4s8H-r82DFjfmNU-dmFPAQVI/edit#heading=h.bsmnc9iehgn
+     * [2] https://github.com/BlueConduit/open-data-platform/pull/195
      */
-    const bakeAndCheckAlarms = [];
+    const bakeCommands = [];
     for (let i = 0; i < PROD_BAKE_DURATION_HOURS; i++) {
-      bakeAndCheckAlarms.push(
-        `sleep ${60 * 60}`, // 1 hour.
-        CHECK_DEV_ALARMS_SCRIPT, // Check for alarms every hour.
+      bakeCommands.push(
+        `sleep ${60 * 60 - 20}`, // 1 hour. Minus buffer to prevent hitting the 1 hour timeout.
       );
     }
     pipeline.addStage(
@@ -156,14 +138,7 @@ export class PipelineStack extends Stack {
         // Bake the release in dev before deploying to prod, to catch any problems early.
         pre: [
           new pipelines.ShellStep('BakeStep', {
-            commands: [
-              ...bakeAndCheckAlarms,
-              // Then wait until a specific (local) time on a weekday, to limit updating to once/day
-              // And to avoid updating out of business hours.
-              `while [ $(date +%H:%M) != "${PROD_RELEASE_TIME}" -o $(date +%u) -gt 5 ]; do sleep 1; done`,
-              // Finally check for alarms before updating.
-              CHECK_DEV_ALARMS_SCRIPT,
-            ],
+            commands: bakeCommands,
           }),
         ],
       },


### PR DESCRIPTION
## Description

Addresses: [prod release bug](https://tables.area120.google.com/table/bX_kMNBW8LA35n6l5Hz_co/row/aYULtWDiYqJ3UfnBL1M4P0)

Prod was failing to deploy with the following:

```
[Container] 2022/10/05 17:46:11 Running command if [[ $( aws cloudwatch describe-alarms --query 'MetricAlarms[?contains(AlarmName, `Dev-OpenDataPlatform`) == `true` && StateValue!=`OK` && !contains(AlarmName, `TargetTracking`)]' --output text) ]]; then exit 1; fi

An error occurred (AccessDenied) when calling the DescribeAlarms operation: User: arn:aws:sts::223904267317:assumed-role/OpenDataPlatformPipeline-PipelineProdBakeStepRole3-TQJ1E0VEFJO2/AWSCodeBuild-c3276479-c035-4255-b25a-f1e5b0630906 is not authorized to perform: cloudwatch:DescribeAlarms on resource: arn:aws:cloudwatch:us-east-2:223904267317:alarm:* because no identity-based policy allows the cloudwatch:DescribeAlarms action
/codebuild/output/tmp/script.sh: 4: [[: not found

[Container] 2022/10/05 17:46:23 Running command sleep 3600
```

There were two problems here:

1. CodeBuild in the deployments account didn't have access to alarms the development account (nor was able to `describe-alarms` at all).
2. The command hit the 1 hour timeout.

This PR removes the bake steps altogether, so prod should update 4 hours after dev. We will have to manually stop the pipeline if there are any problems in dev during that 4 hour window.

In the future we should use a different approach for checking alarms during release. Possibly through another tool like CodeDeploy.

### Changed

- Dropped bake duration from 12 h to 4 h between dev and prod.

### Removed

- Alarm checks and waiting til 9 am for prod.

## Testing and Reviewing

It successfully `npm run pipeline-synth` and we'll have to wait til it's deployed to see if it works.
