### PR TITLE
Reduce bake to <1h

### DIFF
--- a/cdk/src/pipeline/pipeline-stack.ts
+++ b/cdk/src/pipeline/pipeline-stack.ts
@@ -8,19 +8,10 @@ import * as util from '../util';
 import { MonitoringStage, OpenDataPlatformStage } from './stage';
 import { BuildSpec, LinuxBuildImage } from 'aws-cdk-lib/aws-codebuild';
 
-const DEV_BAKE_DURATION_SECS = 20 * 60; // 20 minutes, so ensure the canary runs at least once.
-const PROD_BAKE_DURATION_HOURS = 12;
-const PROD_RELEASE_TIME = '09:00'; // 9 am local (Eastern) time.
+const PROD_BAKE_DURATION_HOURS = 4;
 const CODE_REPO = 'BlueConduit/open-data-platform';
 const CODE_CONNECTION_ARN =
   'arn:aws:codestar-connections:us-east-2:223904267317:connection/cf8a731a-3a36-4e74-ac7f-d93604fd258e';
-// Then check there are no open alarms for dev. This ignores alarms named with
-// "TargetTracking" because those are automatically created by AWS for auto-scaling,
-// which shouldn't affect the release.
-const CHECK_DEV_ALARMS_SCRIPT =
-  "if [[ $( aws cloudwatch describe-alarms --query 'MetricAlarms[?contains(AlarmName, `" +
-  `Dev-${util.projectName}` +
-  "`) == `true` && StateValue!=`OK` && !contains(AlarmName, `TargetTracking`)]' --output text) ]]; then exit 1; fi";
 
 export class PipelineStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
@@ -103,18 +94,6 @@ export class PipelineStack extends Stack {
         tags: { Project: util.projectName, Environment: util.EnvType.Development },
         envType: util.EnvType.Development,
       }),
-      {
-        // Bake the release in dev before deploying to prod, to catch any problems early.
-        post: [
-          new pipelines.ShellStep('BakeStep', {
-            commands: [
-              // Bake a minimum of this duration before calling the stage a success.
-              `sleep ${DEV_BAKE_DURATION_SECS}`,
-              CHECK_DEV_ALARMS_SCRIPT,
-            ],
-          }),
-        ],
-      },
     );
 
     pipeline.addStage(
@@ -131,19 +110,22 @@ export class PipelineStack extends Stack {
       }),
     );
 
-    /* TODO: Consider splitting prod out into its own pipeline.
+    /* TODO: Split prod out into its own pipeline or use CodeDeploy.
      *
      * The prod deployment runs on a different schedule than dev [1]. We chose to use one pipeline
      * for both environments for implementation/ops simplicity. However, this doesn't actually
      * implement a "nightly" release since multiple prod releases could happen within a given day.
      *
+     * We tried implementing a schedule and alarm check in ShellSteps [2], but CodeBuild doesn't
+     * have easy access to the alarm data from other accounts and times out after 1 hour.
+     *
      * [1] https://docs.google.com/document/d/1zZxCoXx5JzLXTOGVdvC4s8H-r82DFjfmNU-dmFPAQVI/edit#heading=h.bsmnc9iehgn
+     * [2] https://github.com/BlueConduit/open-data-platform/pull/195
      */
-    const bakeAndCheckAlarms = [];
+    const bakeCommands = [];
     for (let i = 0; i < PROD_BAKE_DURATION_HOURS; i++) {
-      bakeAndCheckAlarms.push(
-        `sleep ${60 * 60}`, // 1 hour.
-        CHECK_DEV_ALARMS_SCRIPT, // Check for alarms every hour.
+      bakeCommands.push(
+        `sleep ${60 * 60 - 20}`, // 1 hour. Minus buffer to prevent hitting the 1 hour timeout.
       );
     }
     pipeline.addStage(
@@ -156,14 +138,7 @@ export class PipelineStack extends Stack {
         // Bake the release in dev before deploying to prod, to catch any problems early.
         pre: [
           new pipelines.ShellStep('BakeStep', {
-            commands: [
-              ...bakeAndCheckAlarms,
-              // Then wait until a specific (local) time on a weekday, to limit updating to once/day
-              // And to avoid updating out of business hours.
-              `while [ $(date +%H:%M) != "${PROD_RELEASE_TIME}" -o $(date +%u) -gt 5 ]; do sleep 1; done`,
-              // Finally check for alarms before updating.
-              CHECK_DEV_ALARMS_SCRIPT,
-            ],
+            commands: bakeCommands,
           }),
         ],
       },

--- a/cdk/src/pipeline/pipeline-stack.ts
+++ b/cdk/src/pipeline/pipeline-stack.ts
@@ -8,7 +8,6 @@ import * as util from '../util';
 import { MonitoringStage, OpenDataPlatformStage } from './stage';
 import { BuildSpec, LinuxBuildImage } from 'aws-cdk-lib/aws-codebuild';
 
-const PROD_BAKE_DURATION_HOURS = 4;
 const CODE_REPO = 'BlueConduit/open-data-platform';
 const CODE_CONNECTION_ARN =
   'arn:aws:codestar-connections:us-east-2:223904267317:connection/cf8a731a-3a36-4e74-ac7f-d93604fd258e';
@@ -122,12 +121,6 @@ export class PipelineStack extends Stack {
      * [1] https://docs.google.com/document/d/1zZxCoXx5JzLXTOGVdvC4s8H-r82DFjfmNU-dmFPAQVI/edit#heading=h.bsmnc9iehgn
      * [2] https://github.com/BlueConduit/open-data-platform/pull/195
      */
-    const bakeCommands = [];
-    for (let i = 0; i < PROD_BAKE_DURATION_HOURS; i++) {
-      bakeCommands.push(
-        `sleep ${60 * 60 - 20}`, // 1 hour. Minus buffer to prevent hitting the 1 hour timeout.
-      );
-    }
     pipeline.addStage(
       new OpenDataPlatformStage(this, 'Prod', {
         env: { account: '530942487205', region: 'us-east-2' },
@@ -138,7 +131,9 @@ export class PipelineStack extends Stack {
         // Bake the release in dev before deploying to prod, to catch any problems early.
         pre: [
           new pipelines.ShellStep('BakeStep', {
-            commands: bakeCommands,
+            commands: [
+              `sleep ${60 * 60 - 20}`, // 1 hour. Minus buffer to prevent hitting the 1 hour timeout.
+            ],
           }),
         ],
       },


### PR DESCRIPTION
## Description

Addresses: [prod release bug](https://tables.area120.google.com/table/bX_kMNBW8LA35n6l5Hz_co/row/aYULtWDiYqJ3UfnBL1M4P0)

https://github.com/BlueConduit/open-data-platform/pull/218 Tried to address some pipeline problems. But it's still timing out because CodeBuild has a 1h timeout.

### Changed

- Reduce bake to <1h

## Testing and Reviewing

We'll have to see in the pipeline...
