### PR TITLE
History of lead blog post

### DIFF
--- a/client/src/assets/blog/blog_post.ts
+++ b/client/src/assets/blog/blog_post.ts
@@ -1,0 +1,8 @@
+export interface BlogPost {
+  // Title of post.
+  title: string;
+  // Primary image under the header.
+  image: string;
+  // HTML of post, including links, images, etc.
+  content: string;
+}

--- a/client/src/assets/blog/blog_post.ts
+++ b/client/src/assets/blog/blog_post.ts
@@ -1,3 +1,4 @@
+// Minimum content for rendering a post.
 export interface BlogPost {
   // Title of post.
   title: string;

--- a/client/src/assets/blog/history_of_lead.ts
+++ b/client/src/assets/blog/history_of_lead.ts
@@ -1,21 +1,16 @@
-<template>
-  <div :style='cssVars'>
-    <div class='title-section is-flex has-text-centered'>
-      <div class='h1-header-large'>
-        {{ title }}
-      </div>
-    </div>
-    <div class='section is-flex' v-html='content'></div>
-  </div>
-  <p>You may have heard that lead exposure is dangerous, so how did it end up
-    in our water systems? </p>
+import { BlogPost } from '@/assets/blog/blog_post';
+
+export const historyOfLead: BlogPost = {
+  title: 'A Short History of Lead in Water Systems',
+  image: 'next-steps.jpg',
+  content: `<p>You may have heard that lead exposure is dangerous, so how did 
+    it end up in our water systems? </p>
   <p>Lead is a toxic metal that is harmful to human health, but it wasn’t always
     seen as dangerous. In the late 1800s and early 1900s, before the dangers of
     lead were fully documented,
     <a
       href='https://www.epa.gov/ground-water-and-drinking-water/basic-information-about-lead-drinking-water'>
-      many cities in the USA installed lead water
-      pipes </a>.
+      many cities in the USA installed lead water pipes </a>.
     In some cities, use of lead water pipes was even required by the
     local government due to the material’s durability. Because lead water pipes
     can last up to a century, many cities today still have their original pipes
@@ -46,52 +41,5 @@
     their infrastructure, LeadOut helps affected communities take action for
     their health. The first steps are easy - calling your local utility company
     to learn about water testing, ordering a filter, and educating yourself
-    about lead poisoning symptoms.</p>
-</template>
-
-<script lang='ts'>
-import { defineComponent, PropType } from 'vue';
-
-/**
- * Very simple blog page that support title, image, and basic HTML injection.
- */
-export default defineComponent({
-  name: 'BlogView',
-  props: {
-    title: {
-      type: String,
-      default: 'LeadOut Blog',
-    }, content: {
-      type: String,
-      required: true,
-    }, image: {
-      type: String,
-      required: true,
-    },
-  },
-  computed: {
-    cssVars() {
-      return {
-        '--background-image': `url(${require(`@/assets/media/${this.image}`)}`,
-      };
-    },
-  },
-});
-</script>
-
-<style scoped lang='scss'>
-@import '../assets/styles/global.scss';
-@import '@blueconduit/copper/scss/01_settings/design-tokens';
-
-.title-section {
-  @include background-image;
-  @include center-container;
-
-  // Use a semi-opaque gradient to tint the background image for better text readability.
-  background-image: linear-gradient(rgba(0, 96, 100, 0.75), rgba(0, 96, 100, 0.75)), var(--background-image);
-}
-
-.h1-header-large {
-  color: $white;
-}
-</style>
+    about lead poisoning symptoms.</p>`,
+};

--- a/client/src/assets/blog/next_steps.ts
+++ b/client/src/assets/blog/next_steps.ts
@@ -1,7 +1,9 @@
-export class NextSteps {
-  static title = 'You’re at risk for lead in your water. What now?';
-  static image = 'next-steps.jpg';
-  static content = `<p>Learning that your area is at medium or high risk for lead may sound
+import { BlogPost } from '@/assets/blog/blog_post';
+
+export const nextSteps: BlogPost = {
+  title: 'You’re at risk for lead in your water. What now?',
+  image: 'next-steps.jpg',
+  content: `<p>Learning that your area is at medium or high risk for lead may sound
     concerning, however, there are a number of steps you can take immediately to
     protect yourself to feel secure in your home once again. </p>
   <p>The first thing you should know is that testing your water for lead is the
@@ -44,5 +46,5 @@ export class NextSteps {
     and contaminate your water. </p>
   <p>Remember, if you suspect or find out you have lead in your water supply,
     your best bet until pipes can be replaced is to invest in a filter. This
-    simple step can bring back your confidence in your drinking water.</p>`;
-}
+    simple step can bring back your confidence in your drinking water.</p>`,
+};

--- a/client/src/assets/blog/understand_lead_status.ts
+++ b/client/src/assets/blog/understand_lead_status.ts
@@ -1,0 +1,54 @@
+import { BlogPost } from '@/assets/blog/blog_post';
+
+export const understandLead: BlogPost = {
+  title: 'Understanding Your Lead Status\n',
+  image: 'understand-lead.png',
+  content: `<p>So you’ve just checked your area’s lead water pipe contamination risk
+    level? Good! You can now take action to reduce your risk of lead-based
+    health impacts. Don’t see your area listed? Sign up for our mailing list to
+    get notified when new areas are added. </p>
+  <p>You might be wondering how LeadOut determines your area’s risk status.
+    There’s actually a lot that goes into it. To create the tool, water
+    analytics company BlueConduit teamed up with fellows from Google.org to
+    intake and process a lot of data, calculating a risk statuses for certain
+    areas. The things the team looked at were home age, a measurement called the
+    Area Deprivation Index(ADI), and income level. Keep reading for an
+    explanation of how all of these relate to your lead risk status.</p>
+  <div class='h2-header'>Average Home Age</div>
+  <p>While there’s no way to know for sure if you have lead pipes without
+    <a
+      href='https://www.epa.gov/sdwa/use-lead-free-pipes-fittings-fixtures-solder-and-flux-drinking-water#:~:text=In%201986%20Congress%20Amended%20the,providing%20water%20for%20human%20consumption'>
+      examining</a>
+    them (and there are two areas – pipes that go directly into your
+    home and also pipes in the street!), home age can help determine your risk
+    status for lead, because older homes are at a higher risk for lead pipes. If
+    your home’s original plumbing was built before 1986 (when lead in the US was
+    <a
+      href='https://www.epa.gov/sdwa/use-lead-free-pipes-fittings-fixtures-solder-and-flux-drinking-water#:~:text=In%201986%20Congress%20Amended%20the,providing%20water%20for%20human%20consumption.'>
+      banned*</a>
+    from plumbing use), the pipes or the shoulders connecting them are
+    more likely than newer plumbing to be made of lead. Keep in mind, it’s not
+    always just the pipes that affect your water supply – lead could also be
+    hiding in your faucets and other fixtures. </p>
+  <div class='h2-header'>Area Deprivation Index (ADI)</div>
+  <p>This index is a number based on <a
+    href='https://www.neighborhoodatlas.medicine.wisc.edu/'>17 categories</a>
+    that are used to describe socioeconomic disadvantage based on income,
+    education, household characteristics, and housing created by the Health
+    Resources and Services Administration (HRSA). ADIs are often used to
+    determine risks for your health caused by your environment. </p>
+  <div class='h2-header'>Income Level</div>
+  <p>Income levels are also a determining factor in lead risk.The income level
+    for your area is based upon census data and does not reflect each
+    household’s actual income. Because homes in lower-income areas are likely to
+    be older and less likely to have been renovated, lead risk increases in
+    areas where income is lower.
+  </p>
+  <p>Lead risk is a tricky number to pin down and doesn’t determine if you
+    absolutely do or do not have lead pipes, however, those in a high risk
+    status should consider getting their water tested by a professional or
+    buying a filter and should be on the lookout for lead poisoning symptoms. A
+    good first step is calling your water utility to learn more about the
+    options available to you.
+  </p>`,
+};

--- a/client/src/router.ts
+++ b/client/src/router.ts
@@ -7,7 +7,8 @@ import NationwideMapView from '@/views/NationwideMapView.vue';
 import AboutUsView from '@/views/AboutUsView.vue';
 import ThankYouView from '@/views/ThankYouView.vue';
 import BlogView from '@/views/BlogView.vue';
-import { NextSteps } from '@/assets/blog/next_steps';
+import { nextSteps } from '@/assets/blog/next_steps';
+import { historyOfLead } from '@/assets/blog/history_of_lead';
 
 export const LAT_LONG_PARAM = 'latlong';
 export const LAYER_PARAM = 'layer';
@@ -22,6 +23,7 @@ const ABOUT_ROUTE = '/about';
 const RESOURCES_ROUTE = '/resources';
 const SUBSCRIBED_ROUTE = '/subscribed';
 const NEXT_STEPS_ROUTE = '/next-steps';
+const HISTORY_LEAD_ROUTE = '/history-lead';
 
 const routes = [
   {
@@ -80,9 +82,21 @@ const routes = [
       title: `${Titles.APP_TITLE} - ${Titles.BLOG}`,
     },
     props: {
-      title: NextSteps.title,
-      content: NextSteps.content,
-      image: NextSteps.image,
+      title: nextSteps.title,
+      content: nextSteps.content,
+      image: nextSteps.image,
+    },
+  },
+  {
+    path: HISTORY_LEAD_ROUTE,
+    component: BlogView,
+    meta: {
+      title: `${Titles.APP_TITLE} - ${Titles.BLOG}`,
+    },
+    props: {
+      title: historyOfLead.title,
+      content: historyOfLead.content,
+      image: historyOfLead.image,
     },
   },
   {

--- a/client/src/router.ts
+++ b/client/src/router.ts
@@ -9,6 +9,7 @@ import ThankYouView from '@/views/ThankYouView.vue';
 import BlogView from '@/views/BlogView.vue';
 import { nextSteps } from '@/assets/blog/next_steps';
 import { historyOfLead } from '@/assets/blog/history_of_lead';
+import { understandLead } from '@/assets/blog/understand_lead_status';
 
 export const LAT_LONG_PARAM = 'latlong';
 export const LAYER_PARAM = 'layer';
@@ -24,6 +25,7 @@ const RESOURCES_ROUTE = '/resources';
 const SUBSCRIBED_ROUTE = '/subscribed';
 const NEXT_STEPS_ROUTE = '/next-steps';
 const HISTORY_LEAD_ROUTE = '/history-lead';
+const UNDERSTAND_LEAD_ROUTE = '/understand-lead';
 
 const routes = [
   {
@@ -97,6 +99,18 @@ const routes = [
       title: historyOfLead.title,
       content: historyOfLead.content,
       image: historyOfLead.image,
+    },
+  },
+  {
+    path: UNDERSTAND_LEAD_ROUTE,
+    component: BlogView,
+    meta: {
+      title: `${Titles.APP_TITLE} - ${Titles.BLOG}`,
+    },
+    props: {
+      title: understandLead.title,
+      content: understandLead.content,
+      image: understandLead.image,
     },
   },
   {

--- a/client/src/views/BlogView.vue
+++ b/client/src/views/BlogView.vue
@@ -7,46 +7,6 @@
     </div>
     <div class='section is-flex' v-html='content'></div>
   </div>
-  <p>You may have heard that lead exposure is dangerous, so how did it end up
-    in our water systems? </p>
-  <p>Lead is a toxic metal that is harmful to human health, but it wasn’t always
-    seen as dangerous. In the late 1800s and early 1900s, before the dangers of
-    lead were fully documented,
-    <a
-      href='https://www.epa.gov/ground-water-and-drinking-water/basic-information-about-lead-drinking-water'>
-      many cities in the USA installed lead water
-      pipes </a>.
-    In some cities, use of lead water pipes was even required by the
-    local government due to the material’s durability. Because lead water pipes
-    can last up to a century, many cities today still have their original pipes
-    in place. Today, lead is recognized as a significant health risk. There is
-    no concentration of lead in the human body that is considered “safe” as it
-    is known to cause neurological damage as well as varying other dangerous
-    health outcomes. </p>
-  <p>The issue of lead in drinking water is widespread. Lead service lines are
-    likely in use in every US state. The US Environmental Protection Agency
-    (EPA) has estimated that there are currently
-    <a
-      href='https://www.epa.gov/ground-water-and-drinking-water/basic-information-about-lead-drinking-water'>6
-      to 10 million</a> lead service lines across the country.</p>
-  <p>
-    One of the biggest challenges with finding and replacing lead water pipes is
-    that it’s difficult to know exactly which pipes contain lead. Before
-    electronic records, cities recorded information about their water systems in
-    varying levels of detail. Records of pipe locations and materials used in
-    the last century are often inaccurate, lack description, or have even been
-    lost over time. Because the information isn’t readily accessible,
-    BlueConduit works hard to make this information accessible to water
-    utilities and to the general public through LeadOut. Through predictive
-    modeling and persevering on the quest for more data, they’re able to add
-    information to LeadOut over time.
-  </p>
-  <p>Once found, replacing lead pipes is generally expensive and time consuming.
-    While many cities and water systems are working to remove known lead from
-    their infrastructure, LeadOut helps affected communities take action for
-    their health. The first steps are easy - calling your local utility company
-    to learn about water testing, ordering a filter, and educating yourself
-    about lead poisoning symptoms.</p>
 </template>
 
 <script lang='ts'>


### PR DESCRIPTION
## Description

Addresses: 

Blog posts about (1) the history of lead (2) understanding lead status. They are not yet linked.

### Changed

Made BlogPost interface so it's extendable

## Testing and Reviewing

[history](https://screenshot.googleplex.com/5CJ4gAaCfjEz3Lz)
[understanding](https://screenshot.googleplex.com/9hKaxSfxpKCgJQk)