### PR TITLE
feat(cdk): make VPC creation env-independent

### DIFF
--- a/cdk/cdk.context.json
+++ b/cdk/cdk.context.json
@@ -1,47 +1,4 @@
 {
-  "vpc-provider:account=036999211278:filter.vpc-id=vpc-03af3621549e79f22:region=us-east-2:returnAsymmetricSubnets=true": {
-    "vpcId": "vpc-03af3621549e79f22",
-    "vpcCidrBlock": "10.0.0.0/16",
-    "availabilityZones": [],
-    "subnetGroups": [
-      {
-        "name": "private",
-        "type": "Private",
-        "subnets": [
-          {
-            "subnetId": "subnet-077d77e1608090787",
-            "cidr": "10.0.16.0/20",
-            "availabilityZone": "us-east-2a",
-            "routeTableId": "rtb-065349a59f9f4dd4b"
-          },
-          {
-            "subnetId": "subnet-081dcabd017e43f1f",
-            "cidr": "10.0.32.0/20",
-            "availabilityZone": "us-east-2b",
-            "routeTableId": "rtb-0bd3ca3dc8683b8c6"
-          }
-        ]
-      },
-      {
-        "name": "public",
-        "type": "Public",
-        "subnets": [
-          {
-            "subnetId": "subnet-016ca4f97c9aa67ba",
-            "cidr": "10.0.0.0/24",
-            "availabilityZone": "us-east-2a",
-            "routeTableId": "rtb-0c2fa1e949c549af5"
-          },
-          {
-            "subnetId": "subnet-0da62c3943a440750",
-            "cidr": "10.0.1.0/24",
-            "availabilityZone": "us-east-2b",
-            "routeTableId": "rtb-06223de8e27666d5b"
-          }
-        ]
-      }
-    ]
-  },
   "availability-zones:account=530942487205:region=us-east-2": [
     "us-east-2a",
     "us-east-2b",
@@ -49,5 +6,10 @@
   ],
   "acknowledged-issue-numbers": [
     21902
+  ],
+  "availability-zones:account=036999211278:region=us-east-2": [
+    "us-east-2a",
+    "us-east-2b",
+    "us-east-2c"
   ]
 }

--- a/cdk/src/open-data-platform/network/network-stack.ts
+++ b/cdk/src/open-data-platform/network/network-stack.ts
@@ -4,7 +4,7 @@ import { Stack } from 'aws-cdk-lib';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
 import { Construct } from 'constructs';
-import { CommonProps, projectName, EnvType } from '../../util';
+import { CommonProps, EnvType } from '../../util';
 import { Dns } from './dns';
 
 export class NetworkStack extends Stack {
@@ -18,6 +18,7 @@ export class NetworkStack extends Stack {
     this.vpc = new ec2.Vpc(this, 'VPC', {
       cidr: '10.0.0.0/16',
       maxAzs: 2,
+      natGateways: props.envType !== EnvType.Production ? 1 : undefined,
       subnetConfiguration: [
         {
           cidrMask: 24,

--- a/cdk/src/open-data-platform/network/network-stack.ts
+++ b/cdk/src/open-data-platform/network/network-stack.ts
@@ -15,44 +15,22 @@ export class NetworkStack extends Stack {
   constructor(scope: Construct, id: string, props: CommonProps) {
     super(scope, id, props);
 
-    const { envType } = props;
-
-    // This is currently set to always use a new VPC, since we don't yet have a good way to
-    // determine whether to use a new or existing one (and can't dynamically figure that out [1]).
-    // [1] https://github.com/aws/aws-cdk/issues/5305#issuecomment-565394725
-    this.vpc = [EnvType.Development, EnvType.Sandbox].includes(envType)
-      ? // Use an existing VPC.
-        // By default, an AWS account can only have 5 Elastic IP addresses. Reusing existing VPCs keeps
-        // that number down.
-        ec2.Vpc.fromLookup(this, id, {
-          // tags: {
-          //   Project: projectName,
-          // },
-
-          // Temporarily hardcode the ID since the tag lookup was not finding the right VPC.
-          // TODO: replace with search by tag.
-          vpcId: 'vpc-03af3621549e79f22',
-          region: 'us-east-2',
-        })
-      : // Else, create a new VPC.
-        // Note that changes here will not be reflected on deployment if a VPC already exists.
-        // TODO: document how to make a change to an existing VPC.
-        new ec2.Vpc(this, 'VPC', {
-          cidr: '10.0.0.0/16',
-          maxAzs: 2,
-          subnetConfiguration: [
-            {
-              cidrMask: 24,
-              name: 'public',
-              subnetType: ec2.SubnetType.PUBLIC,
-            },
-            {
-              cidrMask: 20,
-              name: 'private',
-              subnetType: ec2.SubnetType.PRIVATE_WITH_NAT,
-            },
-          ],
-        });
+    this.vpc = new ec2.Vpc(this, 'VPC', {
+      cidr: '10.0.0.0/16',
+      maxAzs: 2,
+      subnetConfiguration: [
+        {
+          cidrMask: 24,
+          name: 'public',
+          subnetType: ec2.SubnetType.PUBLIC,
+        },
+        {
+          cidrMask: 20,
+          name: 'private',
+          subnetType: ec2.SubnetType.PRIVATE_WITH_NAT,
+        },
+      ],
+    });
 
     // Set up an ECS shared cluster for other stacks to add services to.
     this.cluster = new ecs.Cluster(this, 'Cluster', {


### PR DESCRIPTION
## Description

Addresses: [Deploy Leadout & Load Data in Dev Env](https://app.shortcut.com/blueconduit/story/6966/deploy-leadout-load-data-in-development-environment)

Currently we do a conditional lookup for an existing VPC resource when:
- deploying to `Development` via pipeline
- deploying to sandbox via `cdk deploy --all`

This lookup is done via a brittle hardcoded `vpcId`. Instead, this PR creates a fresh VPC in all deployment scenarios.

In the future, we may follow an internal pattern (established in `tributary`) to share the same VPC resource between dev sandboxes. This would be desirable because VPC resources are monetarily expensive - having one per dev is a bit cost inefficient. Holding off, though, until we have more clarity on development & maintenance expectations for this repo.

### New

- Ran `cdk synth --profile deployments` to add `Development` AZ lookup context to `cdk.context.json`

### Changed

- Creating VPC in every env instead of doing conditional lookup in sandbox & dev

### Removed

- Removed stale VPC lookup context from `cdk.context.json`

## Testing and Reviewing

- Clean up existing CloudFormation stacks in `Development` env <-- Wait to merge til this is done
- Merge PR & verify that pipeline successfully generates CloudFormation stacks in `Development` env
