### PR TITLE
feat: redirect to https and set noindex,nofollow

### DIFF
--- a/cdk/src/open-data-platform/frontend/frontend-stack.ts
+++ b/cdk/src/open-data-platform/frontend/frontend-stack.ts
@@ -50,7 +50,7 @@ export class FrontendStack extends Stack {
       certificate: networkStack.dns.cloudfrontCertificate,
       defaultBehavior: {
         origin: new origins.S3Origin(this.frontendAssetsBucket),
-        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.ALLOW_ALL,
+        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         responseHeadersPolicy: cloudfront.ResponseHeadersPolicy.SECURITY_HEADERS,
         functionAssociations: [
           {

--- a/cdk/src/pipeline/pipeline-stack.ts
+++ b/cdk/src/pipeline/pipeline-stack.ts
@@ -128,13 +128,14 @@ export class PipelineStack extends Stack {
         envType: util.EnvType.Production,
       }),
       {
-        // Bake the release in dev before deploying to prod, to catch any problems early.
         pre: [
-          new pipelines.ShellStep('BakeStep', {
-            commands: [
-              `sleep ${60 * 60 - 20}`, // 1 hour. Minus buffer to prevent hitting the 1 hour timeout.
-            ],
-          }),
+          // Bake the release in dev before deploying to prod, to catch any problems early.
+          // new pipelines.ShellStep('BakeStep', {
+          //   commands: [
+          //     `sleep ${60 * 60 - 20}`, // 1 hour. Minus buffer to prevent hitting the 1 hour timeout.
+          //   ],
+          // }),
+          new pipelines.ManualApprovalStep('PromoteToProd'),
         ],
       },
     );

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -49,6 +49,9 @@
     </script>
     <% } %>
 
+    <!-- Prevent search engine crawlers from indexing LeadOut or following links for now -->
+    <meta name="robots" content="noindex,nofollow">
+
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />


### PR DESCRIPTION
## Description

Addresses: [Please Noindex Leadout.blueconduit.com for now](https://app.shortcut.com/blueconduit/story/7327/please-noindex-leadout-blueconduit-com-for-now)

- Add ```noindex,nofollow``` meta tag to prevent leadout from being indexed by search engines until it's ready
- Redirect HTTP -> HTTPS through cloudfront
- Replace bake time with manual approval before promoting to Prod to facilitate faster iteration during development

### New

- _Any new things_

### Changed

- _Any changed things_

### Removed

- _Any removed things_

## Testing and Reviewing

We don't have sandbox envs setup for leadout and thanks to an ops event brought to you by EPIC, we'll test in the pipeline.
