### PR TITLE
network: top level redirect to blueconduit.com/lsl-solutions/nationwide-map/

### DIFF
--- a/cdk/src/open-data-platform/frontend/frontend-stack.ts
+++ b/cdk/src/open-data-platform/frontend/frontend-stack.ts
@@ -38,10 +38,23 @@ export class FrontendStack extends Stack {
     // Create s3 bucket to host static assets.
     this.frontendAssetsBucket = new s3.Bucket(this, 'FrontendAssets');
 
-    const redirect4xxFunction = new cloudfront.Function(this, 'Redirect4xxFunction', {
-      functionName: `${id}-redirect4xx`,
-      code: cloudfront.FunctionCode.fromInline(redirect4xx.toString()),
-      comment: `Repalces URL to point to the home route.`,
+    // TODO: will need before launching LeadOut
+    // const redirect4xxFunction = new cloudfront.Function(this, 'Redirect4xxFunction', {
+    //   functionName: `${id}-redirect4xx`,
+    //   code: cloudfront.FunctionCode.fromInline(redirect4xx.toString()),
+    //   comment: `Repalces URL to point to the home route.`,
+    // });
+
+    const redirectToBlueConduitWebsite = new cloudfront.Function(this, 'RedirectToBlueConduit', {
+      code: cloudfront.FunctionCode.fromInline(`
+        function handler(event) {
+          return {
+            statusCode: 302,
+            statusDescription: 'Found',
+            headers: { location: { value: 'https://blueconduit.com/lsl-solutions/nationwide-map/' } }
+          }
+        }
+      `),
     });
 
     // Create CloudFront Distribution that points to frontendAssetsBucket.
@@ -53,8 +66,9 @@ export class FrontendStack extends Stack {
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         responseHeadersPolicy: cloudfront.ResponseHeadersPolicy.SECURITY_HEADERS,
         functionAssociations: [
+          // Temporarily redirect leadout.blueconduit.com to blueconduit.com/lsl-solutions/nationwide-map/
           {
-            function: redirect4xxFunction,
+            function: redirectToBlueConduitWebsite,
             eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
           },
         ],


### PR DESCRIPTION
## Description

Redirect the leadout.blueconduit.com subdomain to a "coming soon" page on the BC marketing website. LeadOut is not ready to be launched to the public yet so this change is in response to learning that EPIC is planning on releasing a blog post linking to leadout.blueconduit.com in a day.

_Short, descriptive summary of the changes_

### New

- _Any new things_

### Changed

- _Any changed things_

### Removed

- _Any removed things_

## Testing and Reviewing

After deploying to the dev environment, go to leadout-dev.blueconduit.com and verify that you get redirected to the right page on the BC marketing website.
