### PR TITLE
Devops/init pipeline build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # LeadOut
 
+[![Seed Status](https://api.seed.run/blueconduit/leadout/stages/staging/build_badge)](https://console.seed.run/blueconduit/leadout)
+[![Seed Status](https://api.seed.run/blueconduit/leadout/stages/prod/build_badge)](https://console.seed.run/blueconduit/leadout)
+
+---
+
 12 Million US households, mostly in low socioeconomic status neighborhoods, live in homes with
 contaminated drinking water supplied from lead pipes and are unable to get the lead out, mainly due
 to lack of awareness and easy access to information on lead pipes and the remediation plan.

--- a/seed.yml
+++ b/seed.yml
@@ -1,0 +1,20 @@
+before_compile:
+  - cd client-new && npm install
+
+# compile:
+#   - echo "Override compile"
+
+# before_build:
+#   - echo "Before build"
+
+# before_deploy:
+#   - echo "Before deploy"
+
+# after_deploy:
+#   - echo "After deploy"
+
+# before_remove:
+#   - echo "Before deploy"
+
+# after_remove:
+#   - echo "After deploy"


### PR DESCRIPTION
## Description

We need to fix the pipeline build.

Since `client-new` is not an npm workspace in the SST project, we need to specifically pre build commands to install node modules in the `client-new` directory.

Setup a [Seed build spec](https://seed.run/docs/adding-a-build-spec.html) to run pre build commands.

Also added deployment badges to the main README.

### New

- `seed.yml` build spec file

### Changed

- _Any changed things_

### Removed

- _Any removed things_

## Testing and Reviewing

Force pushed to main to test these changes.
